### PR TITLE
Add more conditions to `no_undefined` rule

### DIFF
--- a/integration_tests/test_cases/no_undefined/no_undefined.input.zig
+++ b/integration_tests/test_cases/no_undefined/no_undefined.input.zig
@@ -27,3 +27,16 @@ test {
     this_is_a_test_so_who_cares = 0;
     _ = Struct{};
 }
+
+// These should all be ok as they equal or end with the default excluded
+// names "mem", "buffer", etc.
+var buffer: []u8 = undefined;
+var some_buff: []u8 = undefined;
+var some_buf: []u8 = undefined;
+var mem: []u8 = undefined;
+var my_mem: []u8 = undefined;
+var my_memory: []u8 = undefined;
+
+// These will be caught as they're const, even with the name
+const bad_memory: []u8 = undefined;
+const bad_buffer: []u8 = undefined;

--- a/integration_tests/test_cases/no_undefined/no_undefined.lint_expected.stdout
+++ b/integration_tests/test_cases/no_undefined/no_undefined.lint_expected.stdout
@@ -1,3 +1,13 @@
+warning Take care when using `undefined` [test_cases/no_undefined/no_undefined.input.zig:42:26] no_undefined
+
+ 42 | const bad_buffer: []u8 = undefined;
+    |                          ^^^^^^^^^^
+
+warning Take care when using `undefined` [test_cases/no_undefined/no_undefined.input.zig:41:26] no_undefined
+
+ 41 | const bad_memory: []u8 = undefined;
+    |                          ^^^^^^^^^^
+
 warning Take care when using `undefined` [test_cases/no_undefined/no_undefined.input.zig:5:27] no_undefined
 
  5 |     std.fmt.log("{s}", .{ undefined, message });
@@ -13,4 +23,4 @@ warning Take care when using `undefined` [test_cases/no_undefined/no_undefined.i
  1 | var questionable: ?[123]u8 = undefined;
    |                              ^^^^^^^^^^
 
-x 3 warnings
+x 5 warnings

--- a/src/lib/comments.zig
+++ b/src/lib/comments.zig
@@ -53,7 +53,7 @@ pub fn allocParseComments(source: [:0]const u8, allocator: std.mem.Allocator) er
     var index: usize = 0;
     var line: usize = 0;
 
-    var disable_token: []const u8 = undefined;
+    var disable_token: []const u8 = "";
     var disable_token_rule_start_index: usize = 0;
     var disable_token_line: usize = 0;
 

--- a/src/lib/linting.zig
+++ b/src/lib/linting.zig
@@ -954,8 +954,7 @@ pub const LintProblemLocation = struct {
     }
 
     fn debugPrintWithIndent(self: @This(), writer: anytype, indent: usize) void {
-        var spaces: [80]u8 = undefined;
-        @memset(&spaces, ' ');
+        var spaces: [80]u8 = @splat(' ');
         const indent_str = spaces[0..indent];
 
         writer.print("{s}.{{\n", .{indent_str});
@@ -1016,8 +1015,7 @@ pub const LintProblemFix = struct {
     }
 
     fn debugPrintWithIndent(self: @This(), writer: anytype, indent: usize) void {
-        var spaces: [80]u8 = undefined;
-        @memset(&spaces, ' ');
+        var spaces: [80]u8 = @splat(' ');
         const indent_str = spaces[0..indent];
 
         writer.print("{s}.{{\n", .{indent_str});


### PR DESCRIPTION
- Exclude when variable name equals or ends in something (e.g., buffer)

This rule is still undocumented