### PR TITLE
Rewrite comment parser to separate tokenisation

### DIFF
--- a/integration_tests/test_cases/no_cats/disable_current_line.input.zig
+++ b/integration_tests/test_cases/no_cats/disable_current_line.input.zig
@@ -1,0 +1,8 @@
+pub const some_cats = false; // zlinter-disable-current-line
+
+pub const more_cats = false; // zlinter-disable-current-line no_cats
+
+pub const even_more_cats = false; // zlinter-disable-current-line no_cats no_unused - a comment
+
+// Expect to catch this:
+pub const bad_cats = false; // zlinter-disable-current-line no_unused

--- a/integration_tests/test_cases/no_cats/disable_current_line.lint_expected.stdout
+++ b/integration_tests/test_cases/no_cats/disable_current_line.lint_expected.stdout
@@ -1,0 +1,7 @@
+warning I'm allergic to cats [test_cases/no_cats/disable_current_line.input.zig:8:11] no_cats
+
+ 8 | pub const bad_cats = false; // zlinter-disable-current-line no_unused
+   |           ^^^^^^^^
+
+x 1 warnings
+x 3 skipped

--- a/integration_tests/test_cases/no_cats/disable_next_line.input.zig
+++ b/integration_tests/test_cases/no_cats/disable_next_line.input.zig
@@ -1,0 +1,11 @@
+// zlinter-disable-next-line
+pub const some_cats = false;
+
+// zlinter-disable-next-line no_cats
+pub const more_cats = false;
+
+// zlinter-disable-next-line no_cats no_unused - a comment
+pub const even_more_cats = false;
+
+// zlinter-disable-next-line no_unused
+pub const bad_cats = false; // expect to catch this

--- a/integration_tests/test_cases/no_cats/disable_next_line.lint_expected.stdout
+++ b/integration_tests/test_cases/no_cats/disable_next_line.lint_expected.stdout
@@ -1,0 +1,7 @@
+warning I'm allergic to cats [test_cases/no_cats/disable_next_line.input.zig:11:11] no_cats
+
+ 11 | pub const bad_cats = false; // expect to catch this
+    |           ^^^^^^^^
+
+x 1 warnings
+x 3 skipped

--- a/src/exe/run_linter.zig
+++ b/src/exe/run_linter.zig
@@ -240,7 +240,9 @@ pub fn main() !u8 {
             switch (comment.kind) {
                 .standard => {},
                 .todo => |todo| {
-                    std.debug.print("TODO: '{s}'\n", .{ast.source[comments.tokens[todo.first_content].first_byte .. comments.tokens[todo.last_content].last_byte + 1]});
+                    std.debug.print("TODO: '{s}'\n", .{
+                        ast.source[comments.tokens[todo.first_content].first_byte .. comments.tokens[todo.last_content].first_byte + comments.tokens[todo.last_content].len],
+                    });
                 },
                 .todo_empty => {
                     std.debug.print("EMPTY TODO\n", .{});
@@ -252,13 +254,13 @@ pub fn main() !u8 {
                         for (comments.tokens[rule_ids.first .. rule_ids.last + 1]) |token| {
                             std.debug.print(
                                 "- {s}\n",
-                                .{ast.source[token.first_byte .. token.last_byte + 1]},
+                                .{ast.source[token.first_byte .. token.first_byte + token.len]},
                             );
                         }
                     }
                 },
             }
-            std.debug.print("Raw: '{s}'\n\n", .{ast.source[comments.tokens[comment.first_token].first_byte .. comments.tokens[comment.last_token].last_byte + 1]});
+            std.debug.print("Raw: '{s}'\n\n", .{ast.source[comments.tokens[comment.first_token].first_byte .. comments.tokens[comment.last_token].first_byte + comments.tokens[comment.last_token].len]});
         }
 
         if (timer.lapMilliseconds()) |ms| printer.println(.verbose, "  - Parsing doc comments: {d}ms", .{ms});
@@ -497,7 +499,7 @@ fn shouldSkip(doc_comments: zlinter.comments.DocumentComments, err: zlinter.resu
 
                     // Otherwise, we only disable for explicitly given rules.
                     for (doc_comments.tokens[rule_ids.first .. rule_ids.last + 1]) |token| {
-                        const rule_id = source[token.first_byte .. token.last_byte + 1];
+                        const rule_id = source[token.first_byte .. token.first_byte + token.len];
                         if (std.mem.eql(u8, rule_id, err.rule_id)) {
                             return true;
                         }

--- a/src/exe/run_linter.zig
+++ b/src/exe/run_linter.zig
@@ -238,7 +238,6 @@ pub fn main() !u8 {
 
         for (comments.comments) |comment| {
             switch (comment.kind) {
-                .standard => {},
                 .todo => |todo| {
                     std.debug.print("TODO: '{s}'\n", .{
                         ast.source[comments.tokens[todo.first_content].first_byte .. comments.tokens[todo.last_content].first_byte + comments.tokens[todo.last_content].len],

--- a/src/exe/run_linter.zig
+++ b/src/exe/run_linter.zig
@@ -235,7 +235,7 @@ pub fn main() !u8 {
 
         var comments = try zlinter.comments.allocParse(ast.source, gpa);
         defer comments.deinit(gpa);
-        // comments.debugDump(lint_file.pathname, ast.source);
+        // comments.debugPrint(lint_file.pathname, ast.source);
 
         if (timer.lapMilliseconds()) |ms| printer.println(.verbose, "  - Parsing doc comments: {d}ms", .{ms});
 

--- a/src/exe/run_linter.zig
+++ b/src/exe/run_linter.zig
@@ -236,6 +236,31 @@ pub fn main() !u8 {
         var comments = try zlinter.comments.allocParse(ast.source, gpa);
         defer comments.deinit(gpa);
 
+        for (comments.comments) |comment| {
+            switch (comment.kind) {
+                .standard => {},
+                .todo => |todo| {
+                    std.debug.print("TODO: '{s}'\n", .{ast.source[comments.tokens[todo.first_content].first_byte .. comments.tokens[todo.last_content].last_byte + 1]});
+                },
+                .todo_empty => {
+                    std.debug.print("EMPTY TODO\n", .{});
+                },
+                .disable => |disable| {
+                    std.debug.print("DISABLE:\n", .{});
+                    std.debug.print(" for {s}:{d}\n", .{ lint_file.pathname, disable.line_start });
+                    if (disable.rule_ids) |rule_ids| {
+                        for (comments.tokens[rule_ids.first .. rule_ids.last + 1]) |token| {
+                            std.debug.print(
+                                "- {s}\n",
+                                .{ast.source[token.first_byte .. token.last_byte + 1]},
+                            );
+                        }
+                    }
+                },
+            }
+            std.debug.print("Raw: '{s}'\n\n", .{ast.source[comments.tokens[comment.first_token].first_byte .. comments.tokens[comment.last_token].last_byte + 1]});
+        }
+
         if (timer.lapMilliseconds()) |ms| printer.println(.verbose, "  - Parsing doc comments: {d}ms", .{ms});
 
         var rule_filter_map = map: {
@@ -275,7 +300,7 @@ pub fn main() !u8 {
 
             if (rule_result) |result| {
                 for (result.problems) |*err| {
-                    err.disabled_by_comment = shouldSkip(comments.disable_comments, err.*);
+                    err.disabled_by_comment = shouldSkip(comments, err.*, ast.source);
                 }
                 try results.append(gpa, result);
             }
@@ -462,18 +487,24 @@ fn allocAstErrorMsg(
 ///
 /// Returns true if a lint error should be skipped / ignored due to a comment
 /// in the source code.
-fn shouldSkip(disable_comments: []zlinter.comments.LintDisableComment, err: zlinter.results.LintProblem) bool {
-    for (disable_comments) |comment| {
-        if (comment.line_start <= err.start.line and err.start.line <= comment.line_end) {
-            // When there's no explicity rules set, we disable for all rules.
-            if (comment.rule_ids.len == 0) return true;
+fn shouldSkip(doc_comments: zlinter.comments.DocumentComments, err: zlinter.results.LintProblem, source: []const u8) bool {
+    for (doc_comments.comments) |comment| {
+        switch (comment.kind) {
+            .disable => |disable_comment| {
+                if (disable_comment.line_start <= err.start.line and err.start.line <= disable_comment.line_end) {
+                    // When there's no explicity rules set, we disable for all rules.
+                    const rule_ids = disable_comment.rule_ids orelse return true;
 
-            // Otherwise, we only disable for explicitly given rules.
-            for (comment.rule_ids) |rule_id| {
-                if (std.mem.eql(u8, rule_id, err.rule_id)) {
-                    return true;
+                    // Otherwise, we only disable for explicitly given rules.
+                    for (doc_comments.tokens[rule_ids.first .. rule_ids.last + 1]) |token| {
+                        const rule_id = source[token.first_byte .. token.last_byte + 1];
+                        if (std.mem.eql(u8, rule_id, err.rule_id)) {
+                            return true;
+                        }
+                    }
                 }
-            }
+            },
+            else => {},
         }
     }
     return false;

--- a/src/exe/run_linter.zig
+++ b/src/exe/run_linter.zig
@@ -235,32 +235,7 @@ pub fn main() !u8 {
 
         var comments = try zlinter.comments.allocParse(ast.source, gpa);
         defer comments.deinit(gpa);
-
-        for (comments.comments) |comment| {
-            switch (comment.kind) {
-                .todo => |todo| {
-                    std.debug.print("TODO: '{s}'\n", .{
-                        ast.source[comments.tokens[todo.first_content].first_byte .. comments.tokens[todo.last_content].first_byte + comments.tokens[todo.last_content].len],
-                    });
-                },
-                .todo_empty => {
-                    std.debug.print("EMPTY TODO\n", .{});
-                },
-                .disable => |disable| {
-                    std.debug.print("DISABLE:\n", .{});
-                    std.debug.print(" for {s}:{d}\n", .{ lint_file.pathname, disable.line_start });
-                    if (disable.rule_ids) |rule_ids| {
-                        for (comments.tokens[rule_ids.first .. rule_ids.last + 1]) |token| {
-                            std.debug.print(
-                                "- {s}\n",
-                                .{ast.source[token.first_byte .. token.first_byte + token.len]},
-                            );
-                        }
-                    }
-                },
-            }
-            std.debug.print("Raw: '{s}'\n\n", .{ast.source[comments.tokens[comment.first_token].first_byte .. comments.tokens[comment.last_token].first_byte + comments.tokens[comment.last_token].len]});
-        }
+        // comments.debugDump(lint_file.pathname, ast.source);
 
         if (timer.lapMilliseconds()) |ms| printer.println(.verbose, "  - Parsing doc comments: {d}ms", .{ms});
 

--- a/src/lib/comments.zig
+++ b/src/lib/comments.zig
@@ -13,19 +13,19 @@ const Token = struct {
     tag: Tag,
 
     const Tag = enum {
-        /// `///`
+        /// e.g., `///`
         doc_comment,
-        /// `//!`
+        /// e.g., `//!`
         file_comment,
-        /// `//`
+        /// e.g., `//`
         source_comment,
-
-        /// `TODO` or `todo`
+        /// e.g., `TODO`, `Todo`, or `todo`
         todo,
-        /// `zlinter-disable-next-line`
+        /// e.g., `zlinter-disable-next-line`
         disable_lint_current_line,
-        /// `zlinter-disable-current-line`
+        /// e.g., `zlinter-disable-current-line`
         disable_lint_next_line,
+        /// e.g., `:`
         delimiter,
         word,
 
@@ -476,9 +476,9 @@ pub fn allocParse(source: [:0]const u8, gpa: std.mem.Allocator) error{OutOfMemor
                             maybe_last_rule_token = next;
                         },
                         .delimiter => {
-                            // TODO: Add more source information here:
-                            const slice = p.tokens[next].getSlice(source);
-                            std.log.warn("Unexpected delimitor '{s}'. Expected a rule name", .{slice});
+                            // TODO: Maybe one day report this mistake to user, for now lets just ignore it and keeping parsing
+                            // const slice = p.tokens[next].getSlice(source);
+                            // std.log.warn("Unexpected delimitor '{s}'. Expected a rule name", .{slice});
                         },
                         else => break,
                     }

--- a/src/lib/comments.zig
+++ b/src/lib/comments.zig
@@ -5,7 +5,6 @@
 
 const std = @import("std");
 
-/// Contains extracted comments from a documents source.
 pub const DocumentComments = struct {
     tokens: []const Token,
     comments: []const Comment,
@@ -13,13 +12,15 @@ pub const DocumentComments = struct {
     pub fn deinit(self: *DocumentComments, gpa: std.mem.Allocator) void {
         gpa.free(self.comments);
         gpa.free(self.tokens);
-
         self.* = undefined;
     }
 };
 
-/// Represents a comment in the source file
 pub const Comment = struct {
+    /// Inclusive
+    first_token: Token.Index,
+    /// Inclusive
+    last_token: Token.Index,
     kind: union(enum) {
         /// Represents a comment that disables some lint rules within a line range
         /// of a given source file.
@@ -53,27 +54,15 @@ pub const Comment = struct {
             last_content: Token.Index,
         },
     },
-
-    /// Inclusive
-    first_token: Token.Index,
-
-    /// Inclusive
-    last_token: Token.Index,
 };
 
-/// Represents a comment relevant token from a given source.
 const Token = struct {
     const Index = u32;
-
     /// Inclusive
     first_byte: usize,
-
-    /// Inclusive
     len: usize,
-
     /// Line number in source document that this token appears on
     line_number: u32,
-
     tag: Tag,
 
     const Tag = enum {

--- a/src/lib/testing.zig
+++ b/src/lib/testing.zig
@@ -151,14 +151,6 @@ pub fn createFiles(dir: std.fs.Dir, file_paths: [][]const u8) !void {
     }
 }
 
-fn print(comptime fmt: []const u8, args: anytype) void {
-    if (@inComptime()) {
-        @compileError(std.fmt.comptimePrint(fmt, args));
-    } else {
-        std.debug.print(fmt, args);
-    }
-}
-
 inline fn assertTestOnly() void {
     comptime if (!builtin.is_test) @compileError("Test only");
 }

--- a/src/lib/testing.zig
+++ b/src/lib/testing.zig
@@ -151,6 +151,14 @@ pub fn createFiles(dir: std.fs.Dir, file_paths: [][]const u8) !void {
     }
 }
 
+fn print(comptime fmt: []const u8, args: anytype) void {
+    if (@inComptime()) {
+        @compileError(std.fmt.comptimePrint(fmt, args));
+    } else {
+        std.debug.print(fmt, args);
+    }
+}
+
 inline fn assertTestOnly() void {
     comptime if (!builtin.is_test) @compileError("Test only");
 }


### PR DESCRIPTION
The original comment parser was written just for detecting disable comments. Extending to do more (e.g., TODO comments as well) was becoming a bit icky.

The new approach separates tokenising and operates from indexes to tokens in original source to avoid allocating new strings