### PR TITLE
Migrate to std.Build.LazyPath instead of raw []const u8 relative paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,8 @@ add included and excluded paths. For example,
 
 ```zig
 builder.addPaths(.{
-    .include = &.{ "engine-src/", "src/" },
-    .exclude = &.{ "src/android/", "engine-src/generated.zig" },
+    .include = &.{ b.path("engine-src/"), b.path("src/") },
+    .exclude = &.{ b.path("src/android/"), b.path("engine-src/generated.zig") },
 });
 ```
 


### PR DESCRIPTION
Before

```
builder.addPaths(.{
    .include = &.{ b.path("engine-src/"), b.path("src/") },
    .exclude = &.{ b.path("src/android/"), b.path("engine-src/generated.zig") },
});
```

After

```
builder.addPaths(.{
    .include = &.{ b.path("engine-src/"), b.path("src/") },
    .exclude = &.{ b.path("src/android/"), b.path("engine-src/generated.zig") },
});
```