### PR TITLE
Add rule config runtime override support for better integration testing

### DIFF
--- a/integration_tests/build.zig
+++ b/integration_tests/build.zig
@@ -50,6 +50,7 @@ pub fn build(b: *std.Build) !void {
             ".lint_expected.stdout",
             ".fix_expected.stdout",
             ".fix_expected.zig",
+            ".input.zon",
         }) |suffix| {
             addFileArgIfExists(
                 b,
@@ -64,50 +65,10 @@ pub fn build(b: *std.Build) !void {
     const lint_cmd = b.step("lint", "Lint source code.");
     lint_cmd.dependOn(step: {
         var builder = zlinter.builder(b, .{ .target = target, .optimize = optimize });
-        builder.addRule(.{ .builtin = .no_unused }, .{});
-        builder.addRule(.{ .builtin = .no_panic }, .{});
-        builder.addRule(.{ .builtin = .no_comment_out_code }, .{});
-        builder.addRule(.{ .builtin = .no_todo }, .{});
-        builder.addRule(.{ .builtin = .no_undefined }, .{});
-        builder.addRule(.{ .builtin = .require_doc_comment }, .{});
-        builder.addRule(.{ .builtin = .max_positional_args }, .{});
-        builder.addRule(.{ .builtin = .no_literal_args }, .{
-            .detect_string_literal = .@"error",
-            .detect_char_literal = .@"error",
-            .exclude_fn_names = &.{ "excludeFnName", "print" },
-        });
-        builder.addRule(.{ .builtin = .switch_case_ordering }, .{});
-        builder.addRule(.{ .builtin = .field_naming }, .{});
-        builder.addRule(.{ .builtin = .field_ordering }, .{
-            .struct_field_order = .{
-                .order = .alphabetical_descending,
-                .severity = .@"error",
-            },
-            .enum_field_order = .{
-                .order = .alphabetical_ascending,
-                .severity = .warning,
-            },
-            .union_field_order = .{
-                .order = .alphabetical_ascending,
-                .severity = .@"error",
-            },
-        });
-        builder.addRule(.{ .builtin = .declaration_naming }, .{});
-        builder.addRule(.{ .builtin = .function_naming }, .{
-            .function_that_returns_type = .{
-                .severity = .warning,
-                .style = .title_case,
-            },
-        });
-        builder.addRule(.{ .builtin = .file_naming }, .{});
-        builder.addRule(.{ .builtin = .no_deprecated }, .{});
-        builder.addRule(.{ .builtin = .no_inferred_error_unions }, .{});
-        builder.addRule(.{ .builtin = .no_hidden_allocations }, .{});
-        builder.addRule(.{ .builtin = .no_swallow_error }, .{});
-        builder.addRule(.{ .builtin = .no_orelse_unreachable }, .{});
-        builder.addRule(.{ .custom = .{ .name = "no_cats", .path = "src/no_cats.zig" } }, .{
-            .message = "I'm allergic to cats",
-        });
+        inline for (@typeInfo(zlinter.BuiltinLintRule).@"enum".fields) |field| {
+            builder.addRule(.{ .builtin = @enumFromInt(field.value) }, .{});
+        }
+        builder.addRule(.{ .custom = .{ .name = "no_cats", .path = "src/no_cats.zig" } }, .{});
         break :step builder.build();
     });
 }

--- a/integration_tests/test_cases/field_ordering/field_ordering.input.zon
+++ b/integration_tests/test_cases/field_ordering/field_ordering.input.zon
@@ -1,0 +1,14 @@
+.{
+    .struct_field_order = .{
+        .order = .alphabetical_descending,
+        .severity = .@"error",
+    },
+    .enum_field_order = .{
+        .order = .alphabetical_ascending,
+        .severity = .warning,
+    },
+    .union_field_order = .{
+        .order = .alphabetical_ascending,
+        .severity = .@"error",
+    },
+}

--- a/integration_tests/test_cases/function_naming/function_naming.input.zon
+++ b/integration_tests/test_cases/function_naming/function_naming.input.zon
@@ -1,0 +1,6 @@
+.{
+    .function_that_returns_type = .{
+        .severity = .warning,
+        .style = .title_case,
+    },
+}

--- a/integration_tests/test_cases/no_cats/disable_current_line.lint_expected.stdout
+++ b/integration_tests/test_cases/no_cats/disable_current_line.lint_expected.stdout
@@ -1,4 +1,4 @@
-warning I'm allergic to cats [test_cases/no_cats/disable_current_line.input.zig:8:11] no_cats
+warning I'm scared of cats [test_cases/no_cats/disable_current_line.input.zig:8:11] no_cats
 
  8 | pub const bad_cats = false; // zlinter-disable-current-line no_unused
    |           ^^^^^^^^

--- a/integration_tests/test_cases/no_cats/disable_next_line.lint_expected.stdout
+++ b/integration_tests/test_cases/no_cats/disable_next_line.lint_expected.stdout
@@ -1,4 +1,4 @@
-warning I'm allergic to cats [test_cases/no_cats/disable_next_line.input.zig:11:11] no_cats
+warning I'm scared of cats [test_cases/no_cats/disable_next_line.input.zig:11:11] no_cats
 
  11 | pub const bad_cats = false; // expect to catch this
     |           ^^^^^^^^

--- a/integration_tests/test_cases/no_cats/no_cats.input.zon
+++ b/integration_tests/test_cases/no_cats/no_cats.input.zon
@@ -1,0 +1,3 @@
+.{
+    .message = "I'm allergic to cats",
+}

--- a/integration_tests/test_cases/no_literal_args/no_literal_args.input.zon
+++ b/integration_tests/test_cases/no_literal_args/no_literal_args.input.zon
@@ -1,0 +1,5 @@
+.{
+    .detect_string_literal = .@"error",
+    .detect_char_literal = .@"error",
+    .exclude_fn_names = .{ "excludeFnName", "print" },
+}

--- a/no_todo.zon
+++ b/no_todo.zon
@@ -1,0 +1,3 @@
+.{
+    .severity = .@"error",
+}

--- a/no_todo.zon
+++ b/no_todo.zon
@@ -1,3 +1,0 @@
-.{
-    .severity = .@"error",
-}

--- a/src/exe/run_linter.zig
+++ b/src/exe/run_linter.zig
@@ -246,9 +246,15 @@ pub fn main() !u8 {
         defer if (rule_filter_map) |*m| m.deinit(gpa);
 
         printer.println(.verbose, "  - Rules", .{});
+
+        var rule_run_arena = std.heap.ArenaAllocator.init(gpa);
+        defer rule_run_arena.deinit();
+
         for (rules) |rule| {
             if (rule_filter_map) |map|
                 if (!map.contains(rule.rule_id)) continue;
+
+            defer _ = rule_run_arena.reset(.retain_capacity);
 
             const rule_result = try rule.run(
                 rule,
@@ -261,8 +267,13 @@ pub fn main() !u8 {
                             if (rule_config_overrides.get(rule.rule_id)) |zon_path| {
                                 inline for (@typeInfo(configs).@"struct".decls) |decl| {
                                     if (std.mem.eql(u8, rule.rule_id, decl.name)) {
-                                        // TODO: This leaks memory...
-                                        break :config @as(*anyopaque, @constCast(try allocZon(@FieldType(configs, decl.name), zon_path, gpa)));
+                                        break :config @as(*anyopaque, @constCast(
+                                            try allocZon(
+                                                @TypeOf(@field(configs, decl.name)),
+                                                zon_path,
+                                                rule_run_arena.allocator(),
+                                            ),
+                                        ));
                                     }
                                 }
                             }
@@ -642,18 +653,25 @@ fn allocZon(T: type, file_path: []const u8, gpa: std.mem.Allocator) !*T {
     });
     defer file.close();
 
-    const file_content = try file.reader().readAllAlloc(gpa, max_file_size_bytes);
-    defer gpa.free(file_content);
-
-    const null_terminated = try gpa.dupeZ(u8, file_content);
+    const null_terminated = value: {
+        const file_content = try file.reader().readAllAlloc(gpa, max_file_size_bytes);
+        defer gpa.free(file_content);
+        break :value try gpa.dupeZ(u8, file_content);
+    };
     defer gpa.free(null_terminated);
 
-    var status: std.zon.parse.Status = undefined;
+    var status: std.zon.parse.Status = .{};
 
     const result = try gpa.create(T);
     errdefer gpa.destroy(result);
 
-    result.* = std.zon.parse.fromSlice(T, gpa, file_content, &status, .{}) catch |e| {
+    result.* = std.zon.parse.fromSlice(
+        T,
+        gpa,
+        null_terminated,
+        &status,
+        .{},
+    ) catch |e| {
         std.log.err("Failed to parse rule config: " ++ switch (zlinter.version.zig) {
             .@"0.14" => "{}",
             .@"0.15" => "{f}",

--- a/src/lib/Args.zig
+++ b/src/lib/Args.zig
@@ -55,6 +55,10 @@ rules: ?[][]const u8 = null,
 /// Whether to write additional information out to stdout.
 verbose: bool = false,
 
+/// Contains rule id to path names for overriding the build time config for
+/// a rule. This is typically just useful for internal testing.
+rule_config_overrides: ?*std.BufMap = null,
+
 pub fn deinit(self: Args, allocator: std.mem.Allocator) void {
     if (self.zig_exe) |zig_exe|
         allocator.free(zig_exe);
@@ -64,6 +68,11 @@ pub fn deinit(self: Args, allocator: std.mem.Allocator) void {
 
     if (self.zig_lib_directory) |zig_lib_directory|
         allocator.free(zig_lib_directory);
+
+    if (self.rule_config_overrides) |rule_config_overrides| {
+        rule_config_overrides.deinit();
+        allocator.destroy(rule_config_overrides);
+    }
 
     inline for (&.{
         "exclude_paths",
@@ -89,6 +98,7 @@ pub fn allocParse(
     var index: usize = 0;
 
     var lint_args = Args{};
+    errdefer lint_args.deinit(allocator);
 
     var unknown_args = std.ArrayListUnmanaged([]const u8).empty;
     defer unknown_args.deinit(allocator);
@@ -116,6 +126,13 @@ pub fn allocParse(
     var rules = std.ArrayListUnmanaged([]const u8).empty;
     defer rules.deinit(allocator);
 
+    const rule_config_overrides = try allocator.create(std.BufMap);
+    rule_config_overrides.* = std.BufMap.init(allocator);
+    errdefer {
+        rule_config_overrides.deinit();
+        allocator.destroy(rule_config_overrides);
+    }
+
     const State = enum {
         parsing,
         fix_arg,
@@ -131,6 +148,7 @@ pub fn allocParse(
         exclude_path_arg,
         build_include_path_arg,
         build_exclude_path_arg,
+        rule_config_arg,
     };
 
     state: switch (State.parsing) {
@@ -164,6 +182,8 @@ pub fn allocParse(
                     continue :state State.global_cache_root_arg;
                 } else if (std.mem.eql(u8, arg, "--format")) {
                     continue :state State.format_arg;
+                } else if (std.mem.eql(u8, arg, "--rule-config")) {
+                    continue :state State.rule_config_arg;
                 }
                 continue :state State.unknown_arg;
             }
@@ -294,6 +314,28 @@ pub fn allocParse(
             try unknown_args.append(allocator, try allocator.dupe(u8, args[index]));
             continue :state State.parsing;
         },
+        .rule_config_arg => {
+            index += 1;
+            if (index == args.len) {
+                rendering.process_printer.println(.err, "--rule-config arg missing rule id", .{});
+                return error.InvalidArgs;
+            }
+            const rule_id = args[index];
+
+            index += 1;
+            if (index == args.len) {
+                rendering.process_printer.println(.err, "--rule-config arg missing zon file path", .{});
+                return error.InvalidArgs;
+            }
+            const zon_file_path = args[index];
+
+            if (rule_config_overrides.get(rule_id) != null) {
+                rendering.process_printer.println(.err, "--rule-config rule id '{s}' already set", .{rule_id});
+                return error.InvalidArgs;
+            }
+            try rule_config_overrides.put(rule_id, zon_file_path);
+            continue :state State.parsing;
+        },
     }
 
     if (unknown_args.items.len > 0) {
@@ -316,6 +358,12 @@ pub fn allocParse(
     }
     if (rules.items.len > 0) {
         lint_args.rules = try rules.toOwnedSlice(allocator);
+    }
+    if (rule_config_overrides.count() > 0) {
+        lint_args.rule_config_overrides = rule_config_overrides;
+    } else {
+        rule_config_overrides.deinit();
+        allocator.destroy(rule_config_overrides);
     }
 
     return lint_args;
@@ -683,6 +731,10 @@ test "allocParse fuzz" {
         );
         defer args.deinit(std.testing.allocator);
     }
+}
+
+test "allocParse with rule_config arg" {
+    // TODO: Write this before merging!
 }
 
 const testing = struct {


### PR DESCRIPTION
Integration tests can then test different configurations per rule for easier coverage and we can comp time include all built in rules for integration tests instead of needing to remember to configure them all.

The config for the rule is also more cohesive as its stored alongside the input zig file

One downside is we're no longer executing the config from `build.zig` but this should be fine (or we can do a mix of both)