### PR TITLE
Add `zlinter-disable` and `zlinter-enable` comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,22 +225,69 @@ where `Config` struct are found in the rule source files [`no_deprecated.Config`
 
 ### Disable with comments
 
-#### `zlinter-disable-next-line [rule_1] [rule_n] [- comment]`
+#### Disable next line
 
-Disable all rules or an explicit set of rules for the next source code line. For example,
+Disable all rules or an explicit set of rules for the next source code line.
+
+Syntax:
+
+```shell
+zlinter-disable-next-line [rule_1] [rule_n] [- comment]`
+```
+
+For example,
 
 ```zig
 // zlinter-disable-next-line no_deprecated - not updating so safe
 const a = this.is.deprecated();
 ```
 
-#### `zlinter-disable-current-line [rule_1] [rule_n] [- comment]`
+#### Disable current line
 
-Disable all rules or an explicit set of rules for the current source code line. For example,
+Disable all rules or an explicit set of rules for the current source code line.
+
+Syntax:
+
+```shell
+zlinter-disable-current-line [rule_1] [rule_n] [- comment]
+```
+
+For example,
 
 ```zig
 const a = this.is.deprecated(); // zlinter-disable-current-line
 ```
+
+#### Disable multiple lines
+
+Disable all rules or an explicit set of rules for multiple source code lines.
+
+Syntax:
+
+```shell
+zlinter-disable [rule_1] [rule_n] [- comment]
+zlinter-enable [rule_1] [rule_n] [- comment]
+```
+
+For example, to disable multiple lines for a given set of rules:
+
+```zig
+// zlinter-disable rule_a rule_b - rationale
+var something = doSomethin();
+var something_else = doSomethingElse();
+// zlinter-disable rule_a rule_b
+```
+
+For example, to disable multiple lines for all rules:
+
+```zig
+// zlinter-disable - rationale
+var something = doSomethin();
+var something_else = doSomethingElse();
+// zlinter-disable
+```
+
+If you omit `zlinter-enable`, all lines until EOF will be disabled.
 
 ### Command-Line Arguments
 

--- a/integration_tests/src/integration_test.zig
+++ b/integration_tests/src/integration_test.zig
@@ -258,4 +258,3 @@ fn runLintCommand(args: []const []const u8) !std.process.Child.RunResult {
 }
 
 const std = @import("std");
-const builtin = @import("builtin");

--- a/integration_tests/test_cases/no_cats/disable_and_enable_comments.input.zig
+++ b/integration_tests/test_cases/no_cats/disable_and_enable_comments.input.zig
@@ -1,0 +1,25 @@
+pub const bad_cats_1 = false;
+
+// zlinter-disable
+pub const good_cats_1 = false;
+pub const also_good_cats_1 = false;
+// zlinter-enable
+
+pub const bad_cats_2 = false;
+pub const also_bad_cats_2 = false;
+
+// zlinter-disable no_cats
+pub const good_cats_2 = false;
+pub const also_good_cats_2 = false;
+// zlinter-enable no_cats
+
+pub const bad_cats_4 = false;
+pub const also_bad_cats_4 = false;
+
+// zlinter-disable other_rule
+pub const bad_cats_5 = false;
+pub const also_bad_cats_5 = false;
+// zlinter-enable other_rule
+
+pub const bad_cats_6 = false;
+pub const also_bad_cats_6 = false;

--- a/integration_tests/test_cases/no_cats/disable_and_enable_comments.lint_expected.stdout
+++ b/integration_tests/test_cases/no_cats/disable_and_enable_comments.lint_expected.stdout
@@ -1,0 +1,47 @@
+warning I'm scared of cats [test_cases/no_cats/disable_and_enable_comments.input.zig:1:11] no_cats
+
+ 1 | pub const bad_cats_1 = false;
+   |           ^^^^^^^^^^
+
+warning I'm scared of cats [test_cases/no_cats/disable_and_enable_comments.input.zig:8:11] no_cats
+
+ 8 | pub const bad_cats_2 = false;
+   |           ^^^^^^^^^^
+
+warning I'm scared of cats [test_cases/no_cats/disable_and_enable_comments.input.zig:9:11] no_cats
+
+ 9 | pub const also_bad_cats_2 = false;
+   |           ^^^^^^^^^^^^^^^
+
+warning I'm scared of cats [test_cases/no_cats/disable_and_enable_comments.input.zig:16:11] no_cats
+
+ 16 | pub const bad_cats_4 = false;
+    |           ^^^^^^^^^^
+
+warning I'm scared of cats [test_cases/no_cats/disable_and_enable_comments.input.zig:17:11] no_cats
+
+ 17 | pub const also_bad_cats_4 = false;
+    |           ^^^^^^^^^^^^^^^
+
+warning I'm scared of cats [test_cases/no_cats/disable_and_enable_comments.input.zig:20:11] no_cats
+
+ 20 | pub const bad_cats_5 = false;
+    |           ^^^^^^^^^^
+
+warning I'm scared of cats [test_cases/no_cats/disable_and_enable_comments.input.zig:21:11] no_cats
+
+ 21 | pub const also_bad_cats_5 = false;
+    |           ^^^^^^^^^^^^^^^
+
+warning I'm scared of cats [test_cases/no_cats/disable_and_enable_comments.input.zig:24:11] no_cats
+
+ 24 | pub const bad_cats_6 = false;
+    |           ^^^^^^^^^^
+
+warning I'm scared of cats [test_cases/no_cats/disable_and_enable_comments.input.zig:25:11] no_cats
+
+ 25 | pub const also_bad_cats_6 = false;
+    |           ^^^^^^^^^^^^^^^
+
+x 9 warnings
+x 4 skipped

--- a/integration_tests/test_cases/no_panic/no_panic.input.zig
+++ b/integration_tests/test_cases/no_panic/no_panic.input.zig
@@ -1,8 +1,10 @@
+// zlinter-disable no_undefined - also testing irrelevant rule
 pub fn good(x: i32, y: i32) !i32 {
     if (y == 0) return error.DivideByZero;
     return x / y;
 }
 
+// zlinter-disable-next-line no_undefined - also testing irrelevant rule
 pub fn bad(x: i32, y: i32) i32 {
     if (y == 0) @panic("Divide by zero!");
     return x / y;

--- a/integration_tests/test_cases/no_panic/no_panic.lint_expected.stdout
+++ b/integration_tests/test_cases/no_panic/no_panic.lint_expected.stdout
@@ -1,6 +1,6 @@
-warning `@panic` forcibly stops the program at runtime and should be avoided [test_cases/no_panic/no_panic.input.zig:7:17] no_panic
+warning `@panic` forcibly stops the program at runtime and should be avoided [test_cases/no_panic/no_panic.input.zig:9:17] no_panic
 
- 7 |     if (y == 0) @panic("Divide by zero!");
+ 9 |     if (y == 0) @panic("Divide by zero!");
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 x 1 warnings

--- a/src/exe/run_linter.zig
+++ b/src/exe/run_linter.zig
@@ -192,9 +192,6 @@ pub fn main() !u8 {
         };
         defer doc.deinit(ctx.gpa);
 
-        var skipper: zlinter.comments.LazyRuleSkipper = .init(doc.comments, doc.handle.tree.source, gpa);
-        defer skipper.deinit();
-
         if (timer.lapMilliseconds()) |ms|
             printer.println(.verbose, "  - Load document: {d}ms", .{ms})
         else
@@ -296,7 +293,7 @@ pub fn main() !u8 {
 
             if (rule_result) |result| {
                 for (result.problems) |*err| {
-                    err.disabled_by_comment = try skipper.shouldSkip(err.*);
+                    err.disabled_by_comment = try doc.shouldSkipProblem(err.*);
                 }
                 try results.append(gpa, result);
             }

--- a/src/exe/run_linter.zig
+++ b/src/exe/run_linter.zig
@@ -192,6 +192,9 @@ pub fn main() !u8 {
         };
         defer doc.deinit(ctx.gpa);
 
+        var skipper: zlinter.comments.LazyRuleSkipper = .init(doc.comments, doc.handle.tree.source, gpa);
+        defer skipper.deinit();
+
         if (timer.lapMilliseconds()) |ms|
             printer.println(.verbose, "  - Load document: {d}ms", .{ms})
         else
@@ -293,7 +296,7 @@ pub fn main() !u8 {
 
             if (rule_result) |result| {
                 for (result.problems) |*err| {
-                    err.disabled_by_comment = shouldSkip(doc.comments, err.*, ast.source);
+                    err.disabled_by_comment = try skipper.shouldSkip(err.*);
                 }
                 try results.append(gpa, result);
             }
@@ -471,36 +474,6 @@ fn allocAstErrorMsg(
 
     try ast.renderError(err, error_message.writer(allocator));
     return error_message.toOwnedSlice(allocator);
-}
-
-/// An unoptimized algorithm that checks whether a given rule has been disabled
-/// by a comment in the same source file. If files have a lot of disable
-/// comments this algorithm may become a problem (but a lot of disables is an
-/// anti pattern so probably ok?)
-///
-/// Returns true if a lint error should be skipped / ignored due to a comment
-/// in the source code.
-fn shouldSkip(doc_comments: zlinter.comments.CommentsDocument, err: zlinter.results.LintProblem, source: []const u8) bool {
-    for (doc_comments.comments) |comment| {
-        switch (comment.kind) {
-            .disable => |disable_comment| {
-                if (disable_comment.line_start <= err.start.line and err.start.line <= disable_comment.line_end) {
-                    // When there's no explicity rules set, we disable for all rules.
-                    const rule_ids = disable_comment.rule_ids orelse return true;
-
-                    // Otherwise, we only disable for explicitly given rules.
-                    for (doc_comments.tokens[rule_ids.first .. rule_ids.last + 1]) |token| {
-                        const rule_id = source[token.first_byte .. token.first_byte + token.len];
-                        if (std.mem.eql(u8, rule_id, err.rule_id)) {
-                            return true;
-                        }
-                    }
-                }
-            },
-            else => {},
-        }
-    }
-    return false;
 }
 
 // TODO: Move buildExcludesIndex and buildFilterIndex to lib and write unit tests

--- a/src/lib/explorer.zig
+++ b/src/lib/explorer.zig
@@ -169,8 +169,6 @@ fn tokensToJson(tree: std.zig.Ast, arena: std.mem.Allocator) !std.json.Array {
 }
 
 const std = @import("std");
-const session = @import("session.zig");
 const shims = @import("shims.zig");
 const version = @import("version.zig");
-const zls = @import("zls");
 const ast = @import("ast.zig");

--- a/src/lib/session.zig
+++ b/src/lib/session.zig
@@ -8,6 +8,7 @@ pub const LintDocument = struct {
     analyser: *zls.Analyser,
     lineage: *ast.NodeLineage,
     comments: comments.CommentsDocument,
+    skipper: comments.LazyRuleSkipper,
 
     pub fn deinit(self: *LintDocument, gpa: std.mem.Allocator) void {
         while (self.lineage.pop()) |connections| {
@@ -22,6 +23,12 @@ pub const LintDocument = struct {
         gpa.free(self.path);
 
         self.comments.deinit(gpa);
+
+        self.skipper.deinit();
+    }
+
+    pub fn shouldSkipProblem(self: *@This(), problem: LintProblem) error{OutOfMemory}!bool {
+        return self.skipper.shouldSkip(problem);
     }
 
     pub inline fn resolveTypeOfNode(self: @This(), node: std.zig.Ast.Node.Index) !?zls.Analyser.Type {
@@ -470,7 +477,9 @@ pub const LintContext = struct {
             .analyser = try gpa.create(zls.Analyser),
             .lineage = lineage,
             .comments = try comments.allocParse(handle.tree.source, gpa),
+            .skipper = undefined, // zlinter-disable-current-line no_undefined - set below
         };
+        doc.skipper = .init(doc.comments, doc.handle.tree.source, gpa);
 
         doc.analyser.* = switch (version.zig) {
             .@"0.14" => zls.Analyser.init(
@@ -868,3 +877,4 @@ const shims = @import("shims.zig");
 const testing = @import("testing.zig");
 const ast = @import("ast.zig");
 const comments = @import("comments.zig");
+const LintProblem = @import("results.zig").LintProblem;


### PR DESCRIPTION
This also changes the skipping logic to use a bitset for indicating what lines are disabled or enabled