### PR TITLE
 Minor refactor of ansi support #46

### DIFF
--- a/src/exe/run_linter.zig
+++ b/src/exe/run_linter.zig
@@ -52,7 +52,7 @@ pub fn main() !u8 {
     // Technically a chicken and egg problem as you can't rely on verbose stdout
     // while parsing args, so this would probably be better as a build option
     // but for now this should be fine and keeps args together at runtime...
-    zlinter.rendering.process_printer.verbose = args.verbose;
+    zlinter.rendering.process_printer.initAuto(args.verbose);
     var printer = zlinter.rendering.process_printer;
 
     if (args.unknown_args) |unknown_args| {
@@ -135,14 +135,25 @@ pub fn main() !u8 {
     // Print out results:
     // ------------------------------------------------------------------------
     {
-        const output_writer = std.io.getStdOut().writer();
         if (args.fix) {
-            return try runFixes(gpa, dir, file_lint_problems, output_writer);
+            return try runFixes(
+                gpa,
+                dir,
+                file_lint_problems,
+                zlinter.rendering.process_printer.stdout.?,
+            );
         } else {
             const formatter = switch (args.format) {
                 .default => &default_formatter.formatter,
             };
-            return try runFormatter(gpa, dir, file_lint_problems, output_writer, formatter);
+            return try runFormatter(
+                gpa,
+                dir,
+                file_lint_problems,
+                zlinter.rendering.process_printer.stdout.?,
+                zlinter.rendering.process_printer.tty,
+                formatter,
+            );
         }
     }
 }
@@ -351,6 +362,7 @@ fn runFormatter(
     dir: std.fs.Dir,
     file_lint_problems: std.StringArrayHashMap([]zlinter.results.LintResult),
     output_writer: anytype,
+    output_tty: zlinter.ansi.Tty,
     formatter: *const zlinter.formatters.Formatter,
 ) !u8 {
     var arena = std.heap.ArenaAllocator.init(gpa);
@@ -377,6 +389,7 @@ fn runFormatter(
         .results = try flattened.toOwnedSlice(arena_allocator),
         .dir = dir,
         .arena = arena_allocator,
+        .tty = output_tty,
     }, &output_writer);
 
     return exit_code;
@@ -640,9 +653,9 @@ const SlowestItemQueue = struct {
         while (self.queue.removeMaxOrNull()) |item| {
             printer.println(.verbose, "  {d:02} -  {s}[{d}ms]{s} {s}", .{
                 i,
-                zlinter.ansi.get(&.{.bold}),
+                printer.tty.ansiOrEmpty(&.{.bold}),
                 item.elapsed_ns / std.time.ns_per_ms,
-                zlinter.ansi.get(&.{.reset}),
+                printer.tty.ansiOrEmpty(&.{.reset}),
                 item.name,
             });
             i += 1;

--- a/src/lib/ansi.zig
+++ b/src/lib/ansi.zig
@@ -1,34 +1,26 @@
 //! Minimal (keep it this way) ansi helpers
 
-// TODO: Rename to tty.zig and support windows, which requires use of SetConsoleTextAttribute
-// and will then also require changing the design of how this works as we need to
-// accept a writer / handle for the windows API
+pub const Tty = enum {
+    no_color,
+    ansi_color,
 
-var config: ?std.io.tty.Config = null;
+    pub fn init(file: std.fs.File) Tty {
+        if (builtin.is_test) return .no_color;
 
-/// Returns escape sequence for given ansi codes if the platform
-/// supports it (otherwise returns empty string).
-///
-/// This makes it safe to just call whenever writing stdout.
-pub inline fn get(comptime codes: []const Codes) []const u8 {
-    if (builtin.is_test) return "";
-
-    if (config == null) {
-        config = std.io.tty.detectConfig(switch (version.zig) {
-            .@"0.14" => std.io.getStdOut(),
-            .@"0.15" => std.fs.File.stdout(),
-        });
+        return if (std.io.tty.detectConfig(file) == .escape_codes) .ansi_color else .no_color;
     }
 
-    return switch (config.?) {
-        .no_color => "",
-        .escape_codes => sequence(codes),
-        .windows_api => |ctx| if (builtin.os.tag == .windows) windowsSequence(codes, ctx.reset_attributes) else unreachable,
-    };
-}
+    /// Returns the ANSI escape sequence if enabled otherwise an empty string
+    pub fn ansiOrEmpty(self: Tty, comptime codes: []const AnsiCode) []const u8 {
+        return switch (self) {
+            .no_color => "",
+            .ansi_color => comptime sequence(codes),
+        };
+    }
+};
 
 // Only add codes that are being used in the linter:
-const Codes = enum(u32) {
+const AnsiCode = enum(u32) {
     reset = 0,
 
     bold = 1,
@@ -41,43 +33,21 @@ const Codes = enum(u32) {
     green = 32,
     cyan = 36,
 
-    pub fn toWindowsCode(self: @This(), reset: u16) ?u16 {
-        return switch (self) {
-            .reset => reset,
-            .underline => null,
-            .red => std.os.windows.FOREGROUND_RED,
-            .bold => std.os.windows.FOREGROUND_RED | std.os.windows.FOREGROUND_GREEN | std.os.windows.FOREGROUND_BLUE | std.os.windows.FOREGROUND_INTENSITY,
-            .yellow => std.os.windows.FOREGROUND_RED | std.os.windows.FOREGROUND_GREEN,
-            .blue => std.os.windows.FOREGROUND_BLUE,
-            .gray => null,
-            .green => std.os.windows.FOREGROUND_GREEN,
-            .cyan => std.os.windows.FOREGROUND_GREEN | std.os.windows.FOREGROUND_BLUE,
-        };
+    fn toString(comptime self: AnsiCode) []const u8 {
+        return std.fmt.comptimePrint(
+            "{d}",
+            .{@intFromEnum(self)},
+        );
     }
 };
 
-fn windowsSequence(comptime codes: []const Codes, reset: u16) []const u8 {
-    // For now does nothing on windows - see TODO at top of file
-    _ = codes;
-    _ = reset;
-    return "";
-}
-
 // Private as it does not check ansi support, use get(..) instead.
-inline fn sequence(comptime codes: []const Codes) []const u8 {
-    comptime var i: usize = 0;
-    comptime var result: []const u8 = std.fmt.comptimePrint(
-        "{d}",
-        .{@intFromEnum(codes[i])},
-    );
-    i += 1;
-    inline while (i < codes.len) : (i += 1) {
-        result = std.fmt.comptimePrint(
-            "{s};{d}",
-            .{ result, @intFromEnum(codes[i]) },
-        );
+inline fn sequence(comptime codes: []const AnsiCode) []const u8 {
+    comptime var result: []const u8 = codes[0].toString();
+    inline for (1..codes.len) |i| {
+        result = result ++ ";" ++ comptime codes[i].toString();
     }
-    return std.fmt.comptimePrint("\x1B[{s}m", .{result});
+    return "\x1B[" ++ result ++ "m";
 }
 
 test "sequence" {

--- a/src/lib/formatters/Formatter.zig
+++ b/src/lib/formatters/Formatter.zig
@@ -6,6 +6,8 @@ pub const FormatInput = struct {
     dir: std.fs.Dir,
     /// Arena allocator that is cleared after calling format.
     arena: std.mem.Allocator,
+
+    tty: zlinter.ansi.Tty = .no_color,
 };
 
 pub const Error = error{

--- a/src/lib/rendering.zig
+++ b/src/lib/rendering.zig
@@ -49,6 +49,7 @@ pub const LintFileRenderer = struct {
         end_line: usize,
         end_column: usize,
         writer: anytype,
+        tty: ansi.Tty,
     ) !void {
         for (start_line..end_line + 1) |line_index| {
             const is_start = start_line == line_index;
@@ -61,6 +62,7 @@ pub const LintFileRenderer = struct {
                     0,
                     if (self.getLine(line_index).len == 0) 0 else self.getLine(line_index).len - 1,
                     writer,
+                    tty,
                 );
             } else if (is_start and is_end) {
                 try self.renderLine(
@@ -68,6 +70,7 @@ pub const LintFileRenderer = struct {
                     start_column,
                     end_column,
                     writer,
+                    tty,
                 );
             } else if (is_start) {
                 try self.renderLine(
@@ -75,6 +78,7 @@ pub const LintFileRenderer = struct {
                     start_column,
                     if (self.getLine(line_index).len == 0) 0 else self.getLine(line_index).len - 1,
                     writer,
+                    tty,
                 );
             } else if (is_end) {
                 try self.renderLine(
@@ -82,6 +86,7 @@ pub const LintFileRenderer = struct {
                     0,
                     end_column,
                     writer,
+                    tty,
                 );
             } else {
                 @panic("No possible");
@@ -99,6 +104,7 @@ pub const LintFileRenderer = struct {
         column: usize,
         end_column: usize,
         writer: anytype,
+        tty: ansi.Tty,
     ) !void {
         const lhs_format = " {d} ";
         const line_lhs_max_width = comptime std.fmt.comptimePrint(lhs_format, .{std.math.maxInt(@TypeOf(line))}).len;
@@ -106,10 +112,10 @@ pub const LintFileRenderer = struct {
         const lhs = std.fmt.bufPrint(&lhs_buffer, lhs_format, .{line + 1}) catch unreachable;
 
         // LHS of code
-        try writer.writeAll(ansi.get(&.{.cyan}));
+        try writer.writeAll(tty.ansiOrEmpty(&.{.cyan}));
         try writer.writeAll(lhs);
         try writer.writeAll("| ");
-        try writer.writeAll(ansi.get(&.{.reset}));
+        try writer.writeAll(tty.ansiOrEmpty(&.{.reset}));
 
         // Actual code
         try writer.writeAll(self.getLine(line));
@@ -117,16 +123,16 @@ pub const LintFileRenderer = struct {
 
         // LHS of arrows to impacted area
         lhs_buffer = @splat(' ');
-        try writer.writeAll(ansi.get(&.{.gray}));
+        try writer.writeAll(tty.ansiOrEmpty(&.{.gray}));
         try writer.writeAll(lhs_buffer[0..lhs.len]);
         try writer.writeAll("| ");
-        try writer.writeAll(ansi.get(&.{.reset}));
+        try writer.writeAll(tty.ansiOrEmpty(&.{.reset}));
 
         // Actual arrows
         for (0..column) |_| try writer.writeByte(' ');
-        try writer.writeAll(ansi.get(&.{.bold}));
+        try writer.writeAll(tty.ansiOrEmpty(&.{.bold}));
         for (column..end_column + 1) |_| try writer.writeByte('^');
-        try writer.writeAll(ansi.get(&.{.reset}));
+        try writer.writeAll(tty.ansiOrEmpty(&.{.reset}));
     }
 
     pub fn deinit(self: Self, allocator: std.mem.Allocator) void {
@@ -160,6 +166,7 @@ test "LintFileRenderer" {
                 1,
                 5,
                 output.writer(std.testing.allocator),
+                .no_color,
             );
 
             try std.testing.expectEqualStrings(
@@ -178,6 +185,7 @@ test "LintFileRenderer" {
                 1,
                 1,
                 output.writer(std.testing.allocator),
+                .no_color,
             );
 
             try std.testing.expectEqualStrings(
@@ -190,7 +198,7 @@ test "LintFileRenderer" {
     }
 }
 
-var printer_singleton: Printer = .{ .verbose = false };
+var printer_singleton: Printer = .empty;
 /// Singleton printer for use for the lifetime of the process
 pub var process_printer = &printer_singleton;
 
@@ -198,6 +206,33 @@ pub const Printer = struct {
     verbose: bool,
     stdout: ?Writer = null,
     stderr: ?Writer = null,
+    tty: ansi.Tty,
+
+    const empty: Printer = .{ .verbose = false, .tty = .no_color };
+
+    pub fn initAuto(self: *Printer, verbose: bool) void {
+        switch (version.zig) {
+            .@"0.14" => self.init(
+                .{ .context = .{ .file = std.io.getStdOut() } },
+                .{ .context = .{ .file = std.io.getStdErr() } },
+                .init(std.io.getStdOut()),
+                verbose,
+            ),
+            .@"0.15" => self.init(
+                .{ .context = .{ .file = std.fs.File.stdout() } },
+                .{ .context = .{ .file = std.fs.File.stderr() } },
+                .init(std.fs.File.stdout()),
+                verbose,
+            ),
+        }
+    }
+
+    pub fn init(self: *Printer, stdout: Writer, stderr: Writer, tty: ansi.Tty, verbose: bool) void {
+        self.stderr = stderr;
+        self.stdout = stdout;
+        self.tty = tty;
+        self.verbose = verbose;
+    }
 
     pub const Kind = enum {
         out,
@@ -218,11 +253,11 @@ pub const Printer = struct {
     pub fn print(self: Printer, kind: Kind, comptime fmt: []const u8, args: anytype) void {
         var writer: Writer = switch (kind) {
             .verbose => if (self.verbose)
-                self.stdout orelse .{ .context = .{ .file = std.io.getStdOut() } }
+                self.stdout orelse @panic("Requires initAuto or if testing attachFakeStdoutSink")
             else
                 return,
-            .err => self.stderr orelse .{ .context = .{ .file = std.io.getStdErr() } },
-            .out => self.stdout orelse .{ .context = .{ .file = std.io.getStdOut() } },
+            .err => self.stderr orelse @panic("Requires initAuto or if testing attachFakeStderrSink"),
+            .out => self.stdout orelse @panic("Requires initAuto or if testing attachFakeStdoutSink"),
         };
 
         return writer.print(fmt, args) catch |e| {
@@ -308,3 +343,4 @@ inline fn assertTestOnly() void {
 const std = @import("std");
 const ansi = @import("ansi.zig");
 const max_zig_file_size_bytes = @import("session.zig").max_zig_file_size_bytes;
+const version = @import("version.zig");

--- a/src/lib/rendering.zig
+++ b/src/lib/rendering.zig
@@ -228,6 +228,9 @@ pub const Printer = struct {
     }
 
     pub fn init(self: *Printer, stdout: Writer, stderr: Writer, tty: ansi.Tty, verbose: bool) void {
+        std.debug.assert(self.stdout == null);
+        std.debug.assert(self.stderr == null);
+
         self.stderr = stderr;
         self.stdout = stdout;
         self.tty = tty;

--- a/src/lib/rules.zig
+++ b/src/lib/rules.zig
@@ -178,18 +178,16 @@ pub const LintProblemSeverity = enum {
     pub inline fn name(
         self: LintProblemSeverity,
         buffer: *[32]u8,
-        options: struct { ansi: bool = false },
+        options: struct { tty: ansi.Tty = .no_color },
     ) []const u8 {
-        const prefix = if (options.ansi)
+        const prefix =
             switch (self) {
                 .off => unreachable,
-                .warning => ansi.get(&.{ .bold, .yellow }),
-                .@"error" => ansi.get(&.{ .bold, .red }),
-            }
-        else
-            "";
+                .warning => options.tty.ansiOrEmpty(&.{ .bold, .yellow }),
+                .@"error" => options.tty.ansiOrEmpty(&.{ .bold, .red }),
+            };
 
-        const suffix = if (options.ansi) ansi.get(&.{.reset}) else "";
+        const suffix = options.tty.ansiOrEmpty(&.{.reset});
 
         return switch (self) {
             .off => unreachable,

--- a/src/lib/session.zig
+++ b/src/lib/session.zig
@@ -865,11 +865,10 @@ test "LintDocument.resolveTypeKind" {
 
         std.testing.expectEqual(test_case.kind, actual_kind) catch |e| {
             const border: [50]u8 = @splat('-');
-            var writer = std.io.getStdErr().writer();
-            try writer.print("Node:\n{s}\n{s}\n{s}\n", .{ border, doc.handle.tree.getNodeSource(node), border });
-            try writer.print("Expected: {any}\n", .{test_case.kind});
-            try writer.print("Actual: {any}\n", .{actual_kind});
-            try writer.print("Contents:\n{s}\n{s}\n{s}\n", .{ border, test_case.contents, border });
+            std.debug.print("Node:\n{s}\n{s}\n{s}\n", .{ border, doc.handle.tree.getNodeSource(node), border });
+            std.debug.print("Expected: {any}\n", .{test_case.kind});
+            std.debug.print("Actual: {any}\n", .{actual_kind});
+            std.debug.print("Contents:\n{s}\n{s}\n{s}\n", .{ border, test_case.contents, border });
 
             return e;
         };


### PR DESCRIPTION
Removes non-ansi windows WIP support as this is now unplanned. Simpler to just support ANSI which is supported in most terminal environments.