### PR TITLE
BREAKING: Remove ctx from run methods and rename some structs

### DIFF
--- a/integration_tests/src/no_cats.zig
+++ b/integration_tests/src/no_cats.zig
@@ -5,7 +5,7 @@ pub const Config = struct {
     message: ?[]const u8 = null,
 };
 
-pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule {
+pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
     _ = options;
 
     return zlinter.rules.LintRule{
@@ -16,10 +16,9 @@ pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule 
 
 fn run(
     rule: zlinter.rules.LintRule,
-    _: zlinter.session.LintContext,
     doc: zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
-    options: zlinter.session.LintOptions,
+    options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {
     const config = options.getConfig(Config);
     if (config.severity == .off) return null;

--- a/src/exe/run_linter.zig
+++ b/src/exe/run_linter.zig
@@ -370,7 +370,6 @@ fn runLinterRules(
 
             const rule_result = try rule.run(
                 rule,
-                ctx,
                 doc,
                 gpa,
                 .{

--- a/src/lib/rules.zig
+++ b/src/lib/rules.zig
@@ -3,15 +3,23 @@ pub const LintRule = struct {
     rule_id: []const u8,
     run: *const fn (
         self: LintRule,
-        ctx: session.LintContext,
         doc: session.LintDocument,
         allocator: std.mem.Allocator,
-        options: session.LintOptions,
+        options: RunOptions,
     ) error{OutOfMemory}!?results.LintResult,
 };
 
+pub const RunOptions = struct {
+    /// Configuration for the rule. See `getConfig`.
+    config: ?*anyopaque = null,
+
+    pub inline fn getConfig(self: @This(), T: type) T {
+        return if (self.config) |config| @as(*T, @ptrCast(@alignCast(config))).* else T{};
+    }
+};
+
 /// Rules the modify the execution of rules.
-pub const LintRuleOptions = struct {}; // zlinter-disable-current-line
+pub const RuleOptions = struct {}; // zlinter-disable-current-line
 
 pub const LintTextOrder = enum {
     /// Any order

--- a/src/lib/session.zig
+++ b/src/lib/session.zig
@@ -550,14 +550,6 @@ pub const LintContext = struct {
     }
 };
 
-pub const LintOptions = struct {
-    config: ?*anyopaque = null,
-
-    pub inline fn getConfig(self: @This(), T: type) T {
-        return if (self.config) |config| @as(*T, @ptrCast(@alignCast(config))).* else T{};
-    }
-};
-
 test "LintDocument.resolveTypeKind" {
     const TestCase = struct {
         contents: [:0]const u8,

--- a/src/lib/testing.zig
+++ b/src/lib/testing.zig
@@ -144,7 +144,7 @@ pub fn expectNodeOfTagFirst(doc: LintDocument, comptime tags: []const Ast.Node.T
 }
 
 /// Builds and runs a rule with fake file name and content (test only)
-pub fn runRule(rule: LintRule, file_name: []const u8, contents: [:0]const u8, options: LintOptions) !?LintResult {
+pub fn runRule(rule: LintRule, file_name: []const u8, contents: [:0]const u8, options: RunOptions) !?LintResult {
     assertTestOnly();
 
     var ctx: LintContext = undefined;
@@ -177,7 +177,6 @@ pub fn runRule(rule: LintRule, file_name: []const u8, contents: [:0]const u8, op
 
     return try rule.run(
         rule,
-        ctx,
         doc,
         std.testing.allocator,
         options,
@@ -331,7 +330,7 @@ const LintProblemSeverity = @import("rules.zig").LintProblemSeverity;
 const LintProblem = @import("results.zig").LintProblem;
 const LintResult = @import("results.zig").LintResult;
 const LintProblemFix = @import("results.zig").LintProblemFix;
-const LintOptions = @import("session.zig").LintOptions;
+const RunOptions = @import("rules.zig").RunOptions;
 const NodeIndexShim = @import("shims.zig").NodeIndexShim;
 const nodeTag = @import("shims.zig").nodeTag;
 const strings = @import("strings.zig");

--- a/src/rules/declaration_naming.zig
+++ b/src/rules/declaration_naming.zig
@@ -59,7 +59,7 @@ pub const Config = struct {
 };
 
 /// Builds and returns the declaration_naming rule.
-pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule {
+pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
     _ = options;
 
     return zlinter.rules.LintRule{
@@ -71,10 +71,9 @@ pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule 
 /// Runs the declaration_naming rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    _: zlinter.session.LintContext,
     doc: zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
-    options: zlinter.session.LintOptions,
+    options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {
     const config = options.getConfig(Config);
 

--- a/src/rules/field_naming.zig
+++ b/src/rules/field_naming.zig
@@ -75,10 +75,6 @@ pub const Config = struct {
         .severity = .warning,
     },
 
-    // TODO: Add capability for rules to have Context and before all hooks
-    // to precompute information (e.g., for this to become a set or some other
-    // structure more appropriate for these checks).
-
     /// Exclude these `struct` field names from min and max `struct` field name checks.
     struct_field_exclude_len: []const []const u8 = &.{ "x", "y", "z", "i", "b" },
 
@@ -133,7 +129,7 @@ pub const Config = struct {
 };
 
 /// Builds and returns the field_naming rule.
-pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule {
+pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
     _ = options;
 
     return zlinter.rules.LintRule{
@@ -145,10 +141,9 @@ pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule 
 /// Runs the field_naming rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    _: zlinter.session.LintContext,
     doc: zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
-    options: zlinter.session.LintOptions,
+    options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {
     const config = options.getConfig(Config);
 

--- a/src/rules/field_ordering.zig
+++ b/src/rules/field_ordering.zig
@@ -37,7 +37,7 @@ pub const Config = struct {
 };
 
 /// Builds and returns the field_ordering rule.
-pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule {
+pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
     _ = options;
     return zlinter.rules.LintRule{
         .rule_id = @tagName(.field_ordering),
@@ -48,10 +48,9 @@ pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule 
 /// Runs the field_ordering rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    _: zlinter.session.LintContext,
     doc: zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
-    options: zlinter.session.LintOptions,
+    options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {
     const config = options.getConfig(Config);
 

--- a/src/rules/file_naming.zig
+++ b/src/rules/file_naming.zig
@@ -17,7 +17,7 @@ pub const Config = struct {
 };
 
 /// Builds and returns the file_naming rule.
-pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule {
+pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
     _ = options;
 
     return zlinter.rules.LintRule{
@@ -29,12 +29,10 @@ pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule 
 /// Runs the file_naming rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    ctx: zlinter.session.LintContext,
     doc: zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
-    options: zlinter.session.LintOptions,
+    options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {
-    _ = ctx;
     const config = options.getConfig(Config);
 
     const error_message: ?[]const u8, const severity: ?zlinter.rules.LintProblemSeverity = msg: {

--- a/src/rules/function_naming.zig
+++ b/src/rules/function_naming.zig
@@ -53,7 +53,7 @@ pub const Config = struct {
 };
 
 /// Builds and returns the function_naming rule.
-pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule {
+pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
     _ = options;
 
     return zlinter.rules.LintRule{
@@ -65,10 +65,9 @@ pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule 
 /// Runs the function_naming rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    _: zlinter.session.LintContext,
     doc: zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
-    options: zlinter.session.LintOptions,
+    options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {
     const config = options.getConfig(Config);
 

--- a/src/rules/import_ordering.zig
+++ b/src/rules/import_ordering.zig
@@ -43,7 +43,7 @@ pub const Config = struct {
 };
 
 /// Builds and returns the import_ordering rule.
-pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule {
+pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
     _ = options;
 
     return zlinter.rules.LintRule{
@@ -55,10 +55,9 @@ pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule 
 /// Runs the import_ordering rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    _: zlinter.session.LintContext,
     doc: zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
-    options: zlinter.session.LintOptions,
+    options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {
     const config = options.getConfig(Config);
     if (config.severity == .off) return null;

--- a/src/rules/max_positional_args.zig
+++ b/src/rules/max_positional_args.zig
@@ -30,7 +30,7 @@ pub const Config = struct {
 };
 
 /// Builds and returns the max_positional_args rule.
-pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule {
+pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
     _ = options;
 
     return zlinter.rules.LintRule{
@@ -42,10 +42,9 @@ pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule 
 /// Runs the max_positional_args rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    _: zlinter.session.LintContext,
     doc: zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
-    options: zlinter.session.LintOptions,
+    options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {
     const config = options.getConfig(Config);
     if (config.severity == .off) return null;

--- a/src/rules/no_comment_out_code.zig
+++ b/src/rules/no_comment_out_code.zig
@@ -30,7 +30,7 @@ pub const Config = struct {
 };
 
 /// Builds and returns the no_comment_out_code rule.
-pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule {
+pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
     _ = options;
 
     return zlinter.rules.LintRule{
@@ -42,10 +42,9 @@ pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule 
 /// Runs the no_comment_out_code rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    _: zlinter.session.LintContext,
     doc: zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
-    options: zlinter.session.LintOptions,
+    options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {
     const config = options.getConfig(Config);
     if (config.severity == .off) return null;

--- a/src/rules/no_deprecated.zig
+++ b/src/rules/no_deprecated.zig
@@ -12,7 +12,7 @@ pub const Config = struct {
 };
 
 /// Builds and returns the no_deprecated rule.
-pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule {
+pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
     _ = options;
 
     return zlinter.rules.LintRule{
@@ -24,10 +24,9 @@ pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule 
 /// Runs the no_deprecated rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    _: zlinter.session.LintContext,
     doc: zlinter.session.LintDocument,
     gpa: std.mem.Allocator,
-    options: zlinter.session.LintOptions,
+    options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {
     const config = options.getConfig(Config);
     if (config.severity == .off) return null;

--- a/src/rules/no_hidden_allocations.zig
+++ b/src/rules/no_hidden_allocations.zig
@@ -38,7 +38,7 @@ pub const Config = struct {
 };
 
 /// Builds and returns the no_hidden_allocations rule.
-pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule {
+pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
     _ = options;
 
     return zlinter.rules.LintRule{
@@ -50,10 +50,9 @@ pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule 
 /// Runs the no_hidden_allocations rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    _: zlinter.session.LintContext,
     doc: zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
-    options: zlinter.session.LintOptions,
+    options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {
     const config = options.getConfig(Config);
     if (config.severity == .off) return null;

--- a/src/rules/no_inferred_error_unions.zig
+++ b/src/rules/no_inferred_error_unions.zig
@@ -25,7 +25,7 @@ pub const Config = struct {
 };
 
 /// Builds and returns the no_inferred_error_unions rule.
-pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule {
+pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
     _ = options;
 
     return zlinter.rules.LintRule{
@@ -37,10 +37,9 @@ pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule 
 /// Runs the no_inferred_error_unions rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    _: zlinter.session.LintContext,
     doc: zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
-    options: zlinter.session.LintOptions,
+    options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {
     const config = options.getConfig(Config);
     if (config.severity == .off) return null;

--- a/src/rules/no_literal_args.zig
+++ b/src/rules/no_literal_args.zig
@@ -40,7 +40,7 @@ pub const Config = struct {
 };
 
 /// Builds and returns the no_literal_args rule.
-pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule {
+pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
     _ = options;
 
     return zlinter.rules.LintRule{
@@ -54,10 +54,9 @@ const LiteralKind = enum { bool, string, number, char };
 /// Runs the no_literal_args rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    _: zlinter.session.LintContext,
     doc: zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
-    options: zlinter.session.LintOptions,
+    options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {
     const config = options.getConfig(Config);
 

--- a/src/rules/no_literal_only_bool_expression.zig
+++ b/src/rules/no_literal_only_bool_expression.zig
@@ -30,7 +30,7 @@ pub const Config = struct {
 };
 
 /// Builds and returns the no_literal_only_bool_expression rule.
-pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule {
+pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
     _ = options;
 
     return zlinter.rules.LintRule{
@@ -42,10 +42,9 @@ pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule 
 /// Runs the no_literal_only_bool_expression rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    _: zlinter.session.LintContext,
     doc: zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
-    options: zlinter.session.LintOptions,
+    options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {
     const config = options.getConfig(Config);
     if (config.severity == .off) return null;

--- a/src/rules/no_orelse_unreachable.zig
+++ b/src/rules/no_orelse_unreachable.zig
@@ -10,7 +10,7 @@ pub const Config = struct {
 };
 
 /// Builds and returns the no_orelse_unreachable rule.
-pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule {
+pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
     _ = options;
 
     return zlinter.rules.LintRule{
@@ -22,10 +22,9 @@ pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule 
 /// Runs the no_orelse_unreachable rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    _: zlinter.session.LintContext,
     doc: zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
-    options: zlinter.session.LintOptions,
+    options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {
     const config = options.getConfig(Config);
     if (config.severity == .off) return null;

--- a/src/rules/no_panic.zig
+++ b/src/rules/no_panic.zig
@@ -45,7 +45,7 @@ pub const Config = struct {
 };
 
 /// Builds and returns the no_panic rule.
-pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule {
+pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
     _ = options;
 
     return zlinter.rules.LintRule{
@@ -57,10 +57,9 @@ pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule 
 /// Runs the no_panic rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    _: zlinter.session.LintContext,
     doc: zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
-    options: zlinter.session.LintOptions,
+    options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {
     const config = options.getConfig(Config);
     if (config.severity == .off) return null;

--- a/src/rules/no_swallow_error.zig
+++ b/src/rules/no_swallow_error.zig
@@ -21,7 +21,7 @@ pub const Config = struct {
 };
 
 /// Builds and returns the no_swallow_error rule.
-pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule {
+pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
     _ = options;
 
     return zlinter.rules.LintRule{
@@ -33,10 +33,9 @@ pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule 
 /// Runs the no_swallow_error rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    _: zlinter.session.LintContext,
     doc: zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
-    options: zlinter.session.LintOptions,
+    options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {
     const config = options.getConfig(Config);
 

--- a/src/rules/no_todo.zig
+++ b/src/rules/no_todo.zig
@@ -23,7 +23,7 @@ pub const Config = struct {
 };
 
 /// Builds and returns the no_todo rule.
-pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule {
+pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
     _ = options;
 
     return zlinter.rules.LintRule{
@@ -35,10 +35,9 @@ pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule 
 /// Runs the no_todo rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    _: zlinter.session.LintContext,
     doc: zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
-    options: zlinter.session.LintOptions,
+    options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {
     const config = options.getConfig(Config);
     if (config.severity == .off) return null;

--- a/src/rules/no_undefined.zig
+++ b/src/rules/no_undefined.zig
@@ -26,7 +26,7 @@ pub const Config = struct {
 };
 
 /// Builds and returns the no_undefined rule.
-pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule {
+pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
     _ = options;
 
     return zlinter.rules.LintRule{
@@ -38,10 +38,9 @@ pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule 
 /// Runs the no_undefined rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    _: zlinter.session.LintContext,
     doc: zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
-    options: zlinter.session.LintOptions,
+    options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {
     const config = options.getConfig(Config);
     if (config.severity == .off) return null;

--- a/src/rules/no_unused.zig
+++ b/src/rules/no_unused.zig
@@ -11,7 +11,7 @@ pub const Config = struct {
 };
 
 /// Builds and returns the no_unused rule.
-pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule {
+pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
     _ = options;
 
     return zlinter.rules.LintRule{
@@ -23,10 +23,9 @@ pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule 
 /// Runs the no_unused rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    _: zlinter.session.LintContext,
     doc: zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
-    options: zlinter.session.LintOptions,
+    options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {
     const config = options.getConfig(Config);
 

--- a/src/rules/require_doc_comment.zig
+++ b/src/rules/require_doc_comment.zig
@@ -17,7 +17,7 @@ pub const Config = struct {
 };
 
 /// Builds and returns the require_doc_comment rule.
-pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule {
+pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
     _ = options;
 
     return zlinter.rules.LintRule{
@@ -29,10 +29,9 @@ pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule 
 /// Runs the require_doc_comment rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    _: zlinter.session.LintContext,
     doc: zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
-    options: zlinter.session.LintOptions,
+    options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {
     const config = options.getConfig(Config);
 

--- a/src/rules/require_errdefer_dealloc.zig
+++ b/src/rules/require_errdefer_dealloc.zig
@@ -50,7 +50,7 @@ pub const Config = struct {
 };
 
 /// Builds and returns the require_errdefer_dealloc rule.
-pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule {
+pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
     _ = options;
 
     return zlinter.rules.LintRule{
@@ -62,10 +62,9 @@ pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule 
 /// Runs the require_errdefer_dealloc rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    _: zlinter.session.LintContext,
     doc: zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
-    options: zlinter.session.LintOptions,
+    options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {
     const config = options.getConfig(Config);
     if (config.severity == .off) return null;

--- a/src/rules/switch_case_ordering.zig
+++ b/src/rules/switch_case_ordering.zig
@@ -7,7 +7,7 @@ pub const Config = struct {
 };
 
 /// Builds and returns the switch_case_ordering rule.
-pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule {
+pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
     _ = options;
 
     return zlinter.rules.LintRule{
@@ -19,10 +19,9 @@ pub fn buildRule(options: zlinter.rules.LintRuleOptions) zlinter.rules.LintRule 
 /// Runs the switch_case_ordering rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    _: zlinter.session.LintContext,
     doc: zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
-    options: zlinter.session.LintOptions,
+    options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {
     const config = options.getConfig(Config);
     var lint_problems = std.ArrayListUnmanaged(zlinter.results.LintProblem).empty;


### PR DESCRIPTION
Context wasn't being used by any built in rules and so probably wasn't useful and easier to remove now than later

Context may be added back later and extended to include rule specific context for sharing some state between rule runs but for now keeping it simple and removing.

Also:

1. `zlinter.rules.LintRuleOptions` -> `zlinter.rules.RuleOptions `
2. `zlinter.session.LintOptions` -> `zlinter.rules.RunOptions`