### PR TITLE
Refactor to pass lint document by pointer

### DIFF
--- a/integration_tests/src/no_cats.zig
+++ b/integration_tests/src/no_cats.zig
@@ -16,7 +16,7 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: zlinter.session.LintDocument,
+    doc: *zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {

--- a/integration_tests/src/no_cats.zig
+++ b/integration_tests/src/no_cats.zig
@@ -16,7 +16,8 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: *zlinter.session.LintDocument,
+    _: *zlinter.session.LintContext,
+    doc: *const zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {

--- a/src/exe/run_linter.zig
+++ b/src/exe/run_linter.zig
@@ -376,7 +376,7 @@ fn runLinterRules(
             const rule = rules[rule_index];
             if (try rule.run(
                 rule,
-                doc,
+                &doc,
                 gpa,
                 .{ .config = rule_configs[rule_index] },
             )) |result| {

--- a/src/exe/run_linter.zig
+++ b/src/exe/run_linter.zig
@@ -221,6 +221,9 @@ fn runLinterRules(
         slowest_files.unloadAndPrint("Files", printer);
     };
 
+    var arena = std.heap.ArenaAllocator.init(gpa);
+    defer arena.deinit();
+
     var maybe_rule_elapsed_times: ?[rules.len]usize = if (args.verbose)
         @splat(0)
     else
@@ -238,13 +241,13 @@ fn runLinterRules(
         item_timers.unloadAndPrint("Rules", printer);
     };
 
-    var ctx: zlinter.session.LintContext = undefined;
-    try ctx.init(.{
+    var context: zlinter.session.LintContext = undefined;
+    try context.init(.{
         .zig_exe_path = args.zig_exe,
         .zig_lib_path = args.zig_lib_directory,
         .global_cache_path = args.global_cache_root,
-    }, gpa);
-    defer ctx.deinit();
+    }, gpa, arena.allocator());
+    defer context.deinit();
 
     var enabled_rules = enabledRules(args.rules);
 
@@ -260,9 +263,9 @@ fn runLinterRules(
                     if (rule_config_overrides.get(rules[rule_index].rule_id)) |zon_path| {
                         inline for (0..rules_configs_types.len) |i| {
                             if (i == rule_index) {
-                                const arena = config_overrides_arena.allocator();
-                                const config = try arena.create(rules_configs_types[i]);
-                                errdefer arena.destroy(config);
+                                const config_arena = config_overrides_arena.allocator();
+                                const config = try config_arena.create(rules_configs_types[i]);
+                                errdefer config_arena.destroy(config);
 
                                 var diagnostics: zlinter.zon.Diagnostics = .{};
 
@@ -271,7 +274,7 @@ fn runLinterRules(
                                     std.fs.cwd(),
                                     zon_path,
                                     &diagnostics,
-                                    arena,
+                                    config_arena,
                                 ) catch |e| {
                                     switch (e) {
                                         error.ParseZon => {
@@ -315,21 +318,16 @@ fn runLinterRules(
             }
         }
 
-        var arena = std.heap.ArenaAllocator.init(gpa);
-        defer arena.deinit();
-        const arena_allocator = arena.allocator();
-
         var doc: zlinter.session.LintDocument = undefined;
-        ctx.initDocument(
+        context.initDocument(
             lint_file.pathname,
-            ctx.gpa,
-            arena_allocator,
+            context.gpa,
             &doc,
         ) catch |e| {
             printer.println(.err, "Unable to open file: {s} ({s})", .{ lint_file.pathname, @errorName(e) });
             continue :files;
         };
-        defer doc.deinit(ctx.gpa);
+        defer doc.deinit(context.gpa);
 
         if (timer.lapMilliseconds()) |ms|
             printer.println(.verbose, "  - Load document: {d}ms", .{ms})
@@ -376,6 +374,7 @@ fn runLinterRules(
             const rule = rules[rule_index];
             if (try rule.run(
                 rule,
+                &context,
                 &doc,
                 gpa,
                 .{ .config = rule_configs[rule_index] },

--- a/src/exe/run_linter.zig
+++ b/src/exe/run_linter.zig
@@ -319,8 +319,14 @@ fn runLinterRules(
         defer arena.deinit();
         const arena_allocator = arena.allocator();
 
-        var doc = try ctx.loadDocument(lint_file.pathname, ctx.gpa, arena_allocator) orelse {
-            printer.println(.err, "Unable to open file: {s}", .{lint_file.pathname});
+        var doc: zlinter.session.LintDocument = undefined;
+        ctx.initDocument(
+            lint_file.pathname,
+            ctx.gpa,
+            arena_allocator,
+            &doc,
+        ) catch |e| {
+            printer.println(.err, "Unable to open file: {s} ({s})", .{ lint_file.pathname, @errorName(e) });
             continue :files;
         };
         defer doc.deinit(ctx.gpa);

--- a/src/lib/ast.zig
+++ b/src/lib/ast.zig
@@ -121,7 +121,7 @@ pub const DeferBlock = struct {
     }
 };
 
-pub fn deferBlock(doc: *session.LintDocument, node: Ast.Node.Index, allocator: std.mem.Allocator) !?DeferBlock {
+pub fn deferBlock(doc: *const session.LintDocument, node: Ast.Node.Index, allocator: std.mem.Allocator) !?DeferBlock {
     const tree = doc.handle.tree;
 
     const data = shims.nodeData(tree, node);
@@ -608,7 +608,7 @@ test "isEnumLiteral" {
 /// Checks whether the current node is a function call or contains one in its
 /// children.
 pub fn findFnCall(
-    doc: *session.LintDocument,
+    doc: *const session.LintDocument,
     node: Ast.Node.Index,
     call_buffer: *[1]Ast.Node.Index,
     comptime names: []const []const u8,
@@ -670,7 +670,7 @@ pub const FnCall = struct {
 ///
 /// If names is empty, then it'll match all function names.
 pub fn fnCall(
-    doc: *session.LintDocument,
+    doc: *const session.LintDocument,
     node: Ast.Node.Index,
     buffer: *[1]Ast.Node.Index,
     comptime names: []const []const u8,

--- a/src/lib/ast.zig
+++ b/src/lib/ast.zig
@@ -16,7 +16,7 @@ pub const NodeAncestorIterator = struct {
     const Self = @This();
 
     current: NodeIndexShim,
-    lineage: *NodeLineage,
+    lineage: *const NodeLineage,
     done: bool = false,
 
     pub fn next(self: *Self) ?Ast.Node.Index {
@@ -37,7 +37,7 @@ pub const NodeLineageIterator = struct {
     const Self = @This();
 
     queue: shims.ArrayList(NodeIndexShim) = .empty,
-    lineage: *NodeLineage,
+    lineage: *const NodeLineage,
     gpa: std.mem.Allocator,
 
     pub fn deinit(self: *NodeLineageIterator) void {

--- a/src/lib/ast.zig
+++ b/src/lib/ast.zig
@@ -219,14 +219,13 @@ test "deferBlock - has expected children" {
         var tmp = std.testing.tmpDir(.{});
         defer tmp.cleanup();
 
-        var doc = try testing.loadFakeDocument(
+        const doc = try testing.loadFakeDocument(
             &context,
             tmp.dir,
             "test.zig",
             "fn main() void {\n" ++ source ++ "\n}",
             arena.allocator(),
         );
-        _ = &doc;
 
         const decl_ref = try deferBlock(
             doc,

--- a/src/lib/ast.zig
+++ b/src/lib/ast.zig
@@ -121,7 +121,7 @@ pub const DeferBlock = struct {
     }
 };
 
-pub fn deferBlock(doc: session.LintDocument, node: Ast.Node.Index, allocator: std.mem.Allocator) !?DeferBlock {
+pub fn deferBlock(doc: *session.LintDocument, node: Ast.Node.Index, allocator: std.mem.Allocator) !?DeferBlock {
     const tree = doc.handle.tree;
 
     const data = shims.nodeData(tree, node);
@@ -229,7 +229,7 @@ test "deferBlock - has expected children" {
         defer doc.deinit(arena.allocator());
 
         const decl_ref = try deferBlock(
-            doc,
+            &doc,
             try testing.expectSingleNodeOfTag(doc.handle.tree, &.{ .@"defer", .@"errdefer" }),
             std.testing.allocator,
         );
@@ -608,7 +608,7 @@ test "isEnumLiteral" {
 /// Checks whether the current node is a function call or contains one in its
 /// children.
 pub fn findFnCall(
-    doc: session.LintDocument,
+    doc: *session.LintDocument,
     node: Ast.Node.Index,
     call_buffer: *[1]Ast.Node.Index,
     comptime names: []const []const u8,
@@ -670,7 +670,7 @@ pub const FnCall = struct {
 ///
 /// If names is empty, then it'll match all function names.
 pub fn fnCall(
-    doc: session.LintDocument,
+    doc: *session.LintDocument,
     node: Ast.Node.Index,
     buffer: *[1]Ast.Node.Index,
     comptime names: []const []const u8,

--- a/src/lib/ast.zig
+++ b/src/lib/ast.zig
@@ -212,24 +212,24 @@ test "deferBlock - has expected children" {
 
         defer _ = arena.reset(.retain_capacity);
 
-        var ctx: session.LintContext = undefined;
-        try ctx.init(.{}, arena.allocator());
-        defer ctx.deinit();
+        var context: session.LintContext = undefined;
+        try context.init(.{}, std.testing.allocator, arena.allocator());
+        defer context.deinit();
 
         var tmp = std.testing.tmpDir(.{});
         defer tmp.cleanup();
 
         var doc = try testing.loadFakeDocument(
-            &ctx,
+            &context,
             tmp.dir,
             "test.zig",
             "fn main() void {\n" ++ source ++ "\n}",
             arena.allocator(),
         );
-        defer doc.deinit(arena.allocator());
+        _ = &doc;
 
         const decl_ref = try deferBlock(
-            &doc,
+            doc,
             try testing.expectSingleNodeOfTag(doc.handle.tree, &.{ .@"defer", .@"errdefer" }),
             std.testing.allocator,
         );

--- a/src/lib/rules.zig
+++ b/src/lib/rules.zig
@@ -3,8 +3,9 @@ pub const LintRule = struct {
     rule_id: []const u8,
     run: *const fn (
         self: LintRule,
-        doc: *session.LintDocument,
-        allocator: std.mem.Allocator,
+        context: *session.LintContext,
+        doc: *const session.LintDocument,
+        gpa: std.mem.Allocator,
         options: RunOptions,
     ) error{OutOfMemory}!?results.LintResult,
 };
@@ -224,3 +225,4 @@ const session = @import("session.zig");
 const std = @import("std");
 const strings = @import("strings.zig");
 const testing = @import("testing.zig");
+const zls = @import("zls");

--- a/src/lib/rules.zig
+++ b/src/lib/rules.zig
@@ -3,7 +3,7 @@ pub const LintRule = struct {
     rule_id: []const u8,
     run: *const fn (
         self: LintRule,
-        doc: session.LintDocument,
+        doc: *session.LintDocument,
         allocator: std.mem.Allocator,
         options: RunOptions,
     ) error{OutOfMemory}!?results.LintResult,

--- a/src/lib/rules.zig
+++ b/src/lib/rules.zig
@@ -225,4 +225,3 @@ const session = @import("session.zig");
 const std = @import("std");
 const strings = @import("strings.zig");
 const testing = @import("testing.zig");
-const zls = @import("zls");

--- a/src/lib/session.zig
+++ b/src/lib/session.zig
@@ -30,10 +30,13 @@ pub const LintDocument = struct {
         self.skipper.deinit();
     }
 
+    /// Returns true if the problem should be skipped based on line level
+    /// disable comments.
     pub fn shouldSkipProblem(self: *LintDocument, problem: LintProblem) error{OutOfMemory}!bool {
         return self.skipper.shouldSkip(problem);
     }
 
+    /// Resolves the type of node or null if it can't be resolved.
     pub inline fn resolveTypeOfNode(self: *LintDocument, node: Ast.Node.Index) !?zls.Analyser.Type {
         return switch (version.zig) {
             .@"0.15", .@"0.16" => self.analyser.resolveTypeOfNode(.of(node, self.handle)),
@@ -41,6 +44,8 @@ pub const LintDocument = struct {
         };
     }
 
+    /// Resolves the type of a node that points to a type (e.g., return type) or
+    /// null if it cannot be resolved.
     pub inline fn resolveTypeOfTypeNode(self: *LintDocument, node: Ast.Node.Index) !?zls.Analyser.Type {
         const resolved_type = try self.resolveTypeOfNode(node) orelse return null;
         const instance_type = if (resolved_type.isMetaType()) resolved_type else switch (version.zig) {
@@ -310,6 +315,9 @@ pub const LintDocument = struct {
         };
     }
 
+    /// Walks down from the current node does its children.
+    ///
+    /// This includes the given node in the traversal.
     pub fn nodeLineageIterator(
         self: *const LintDocument,
         node: NodeIndexShim,

--- a/src/lib/session.zig
+++ b/src/lib/session.zig
@@ -638,14 +638,13 @@ test "LintDocument.isEnclosedInTestBlock" {
         \\}
     ;
 
-    var doc = try testing.loadFakeDocument(
+    const doc = try testing.loadFakeDocument(
         &context,
         tmp.dir,
         "test.zig",
         source,
         arena.allocator(),
     );
-    _ = &doc;
 
     try std.testing.expect(
         !doc.isEnclosedInTestBlock(.init(try testing.expectVarDecl(
@@ -1006,14 +1005,13 @@ test "LintContext.resolveTypeKind" {
         var tmp = std.testing.tmpDir(.{});
         defer tmp.cleanup();
 
-        var doc = try testing.loadFakeDocument(
+        const doc = try testing.loadFakeDocument(
             &context,
             tmp.dir,
             "test.zig",
             test_case.contents,
             arena.allocator(),
         );
-        _ = &doc;
 
         const node = doc.handle.tree.rootDecls()[0];
         const actual_kind = if (doc.handle.tree.fullVarDecl(node)) |var_decl|

--- a/src/lib/testing.zig
+++ b/src/lib/testing.zig
@@ -216,14 +216,13 @@ fn runRule(rule: LintRule, file_name: []const u8, contents: [:0]const u8, option
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    var doc = try loadFakeDocument(
+    const doc = try loadFakeDocument(
         &context,
         tmp.dir,
         file_name,
         contents,
         arena.allocator(),
     );
-    _ = &doc;
 
     const tree = doc.handle.tree;
     std.testing.expectEqual(tree.errors.len, 0) catch |err| {

--- a/src/lib/testing.zig
+++ b/src/lib/testing.zig
@@ -239,7 +239,7 @@ fn runRule(rule: LintRule, file_name: []const u8, contents: [:0]const u8, option
 
     return try rule.run(
         rule,
-        doc,
+        &doc,
         std.testing.allocator,
         options,
     );

--- a/src/lib/testing.zig
+++ b/src/lib/testing.zig
@@ -24,7 +24,9 @@ pub fn loadFakeDocument(
     try file_writer.interface.writeAll(contents);
     try file_writer.interface.flush();
 
-    return (try ctx.loadDocument(real_path, ctx.gpa, arena)).?;
+    const doc = try arena.create(LintDocument);
+    try ctx.initDocument(real_path, ctx.gpa, arena, doc);
+    return doc.*;
 }
 
 pub fn writeFile(dir: std.fs.Dir, file_name: []const u8, contents: []const u8) !void {

--- a/src/lib/testing.zig
+++ b/src/lib/testing.zig
@@ -2,12 +2,12 @@
 
 /// See `runRule` for example (test only)
 pub fn loadFakeDocument(
-    ctx: *LintContext,
+    context: *LintContext,
     dir: std.fs.Dir,
     file_name: []const u8,
     contents: [:0]const u8,
     arena: std.mem.Allocator,
-) !LintDocument {
+) !*LintDocument {
     assertTestOnly();
 
     if (std.fs.path.dirname(file_name)) |dir_name|
@@ -25,8 +25,8 @@ pub fn loadFakeDocument(
     try file_writer.interface.flush();
 
     const doc = try arena.create(LintDocument);
-    try ctx.initDocument(real_path, ctx.gpa, arena, doc);
-    return doc.*;
+    try context.initDocument(real_path, arena, doc);
+    return doc;
 }
 
 pub fn writeFile(dir: std.fs.Dir, file_name: []const u8, contents: []const u8) !void {
@@ -184,7 +184,7 @@ pub fn expectSingleNodeOfTag(tree: Ast, comptime tags: []const Ast.Node.Tag) !As
 }
 
 /// Expects at least one node and returns it matching a set of tags
-pub fn expectNodeOfTagFirst(doc: LintDocument, comptime tags: []const Ast.Node.Tag) !Ast.Node.Index {
+pub fn expectNodeOfTagFirst(doc: *const LintDocument, comptime tags: []const Ast.Node.Tag) !Ast.Node.Index {
     assertTestOnly();
 
     var it = try doc.nodeLineageIterator(.root, std.testing.allocator);
@@ -206,24 +206,24 @@ pub fn expectNodeOfTagFirst(doc: LintDocument, comptime tags: []const Ast.Node.T
 fn runRule(rule: LintRule, file_name: []const u8, contents: [:0]const u8, options: RunOptions) !?LintResult {
     assertTestOnly();
 
-    var ctx: LintContext = undefined;
-    try ctx.init(.{}, std.testing.allocator);
-    defer ctx.deinit();
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    var context: LintContext = undefined;
+    try context.init(.{}, std.testing.allocator, arena.allocator());
+    defer context.deinit();
 
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-
     var doc = try loadFakeDocument(
-        &ctx,
+        &context,
         tmp.dir,
         file_name,
         contents,
         arena.allocator(),
     );
-    defer doc.deinit(ctx.gpa);
+    _ = &doc;
 
     const tree = doc.handle.tree;
     std.testing.expectEqual(tree.errors.len, 0) catch |err| {
@@ -239,7 +239,8 @@ fn runRule(rule: LintRule, file_name: []const u8, contents: [:0]const u8, option
 
     return try rule.run(
         rule,
-        &doc,
+        &context,
+        doc,
         std.testing.allocator,
         options,
     );
@@ -377,12 +378,12 @@ pub fn initDocForTesting(
 ) !*LintDocument {
     _ = options;
 
-    var ctx: *LintContext = try arena.create(LintContext);
-    errdefer arena.destroy(ctx);
+    var context: *LintContext = try arena.create(LintContext);
+    errdefer arena.destroy(context);
 
-    ctx.* = undefined;
-    try ctx.init(.{}, arena);
-    errdefer ctx.deinit();
+    context.* = undefined;
+    try context.init(.{}, arena);
+    errdefer context.deinit();
 
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -391,7 +392,7 @@ pub fn initDocForTesting(
     errdefer arena.destroy(doc);
 
     doc.* = try loadFakeDocument(
-        ctx,
+        context,
         tmp.dir,
         "test.zig",
         source,

--- a/src/lib/testing.zig
+++ b/src/lib/testing.zig
@@ -402,8 +402,8 @@ pub fn initDocForTesting(
 }
 
 const builtin = @import("builtin");
-const std = @import("std");
 const session = @import("session.zig");
+const std = @import("std");
 const LintContext = session.LintContext;
 const LintDocument = session.LintDocument;
 const LintRule = @import("rules.zig").LintRule;

--- a/src/rules/declaration_naming.zig
+++ b/src/rules/declaration_naming.zig
@@ -90,7 +90,8 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the declaration_naming rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: *zlinter.session.LintDocument,
+    context: *zlinter.session.LintContext,
+    doc: *const zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {
@@ -116,7 +117,7 @@ fn run(
             if (token_tag == .keyword_export) continue :nodes;
         }
 
-        const type_kind = try doc.resolveTypeKind(.{ .var_decl = var_decl }) orelse continue :nodes;
+        const type_kind = try context.resolveTypeKind(doc, .{ .var_decl = var_decl }) orelse continue :nodes;
         const name_token = var_decl.ast.mut_token + 1;
         const name = zlinter.strings.normalizeIdentifierName(tree.tokenSlice(name_token));
 

--- a/src/rules/declaration_naming.zig
+++ b/src/rules/declaration_naming.zig
@@ -90,7 +90,7 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the declaration_naming rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: zlinter.session.LintDocument,
+    doc: *zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {

--- a/src/rules/field_naming.zig
+++ b/src/rules/field_naming.zig
@@ -141,7 +141,8 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the field_naming rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: *zlinter.session.LintDocument,
+    context: *zlinter.session.LintContext,
+    doc: *const zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {
@@ -219,8 +220,8 @@ fn run(
 
             fields: for (container_decl.ast.members) |member| {
                 if (tree.fullContainerField(member)) |container_field| {
-                    const type_kind = try doc.resolveTypeKind(.{ .container_field = container_field });
-                    const style_with_severity: zlinter.rules.LintTextStyleWithSeverity, const container_kind: zlinter.session.LintDocument.TypeKind = tuple: {
+                    const type_kind = try context.resolveTypeKind(doc, .{ .container_field = container_field });
+                    const style_with_severity: zlinter.rules.LintTextStyleWithSeverity, const container_kind: zlinter.session.LintContext.TypeKind = tuple: {
                         break :tuple switch (container_tag) {
                             .keyword_struct => if (type_kind) |kind|
                                 switch (kind) {

--- a/src/rules/field_naming.zig
+++ b/src/rules/field_naming.zig
@@ -141,7 +141,7 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the field_naming rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: zlinter.session.LintDocument,
+    doc: *zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {

--- a/src/rules/field_ordering.zig
+++ b/src/rules/field_ordering.zig
@@ -48,7 +48,7 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the field_ordering rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: zlinter.session.LintDocument,
+    doc: *zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {

--- a/src/rules/field_ordering.zig
+++ b/src/rules/field_ordering.zig
@@ -48,7 +48,8 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the field_ordering rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: *zlinter.session.LintDocument,
+    _: *zlinter.session.LintContext,
+    doc: *const zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {

--- a/src/rules/file_naming.zig
+++ b/src/rules/file_naming.zig
@@ -29,7 +29,8 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the file_naming rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: *zlinter.session.LintDocument,
+    _: *zlinter.session.LintContext,
+    doc: *const zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {

--- a/src/rules/file_naming.zig
+++ b/src/rules/file_naming.zig
@@ -29,7 +29,7 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the file_naming rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: zlinter.session.LintDocument,
+    doc: *zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {

--- a/src/rules/function_naming.zig
+++ b/src/rules/function_naming.zig
@@ -65,7 +65,7 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the function_naming rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: zlinter.session.LintDocument,
+    doc: *zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {

--- a/src/rules/function_naming.zig
+++ b/src/rules/function_naming.zig
@@ -65,7 +65,8 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the function_naming rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: *zlinter.session.LintDocument,
+    context: *zlinter.session.LintContext,
+    doc: *const zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {
@@ -92,7 +93,8 @@ fn run(
             const fn_name_token = fn_proto.name_token.?;
             const fn_name = zlinter.strings.normalizeIdentifierName(tree.tokenSlice(fn_name_token));
 
-            const return_type = (try doc.resolveTypeOfTypeNode(
+            const return_type = (try context.resolveTypeOfTypeNode(
+                doc,
                 switch (zlinter.version.zig) {
                     .@"0.14" => fn_proto.ast.return_type,
                     .@"0.15", .@"0.16" => fn_proto.ast.return_type.unwrap().?,
@@ -153,7 +155,7 @@ fn run(
 
                 if (identifier.len == 1 and identifier[0] == '_') continue;
 
-                if (try doc.resolveTypeOfTypeNode(param)) |param_type| {
+                if (try context.resolveTypeOfTypeNode(doc, param)) |param_type| {
                     const style_with_severity: zlinter.rules.LintTextStyleWithSeverity, const desc: []const u8 =
                         if (param_type.isTypeFunc())
                             .{ config.function_arg_that_is_type_fn, "Function argument of type function" }

--- a/src/rules/import_ordering.zig
+++ b/src/rules/import_ordering.zig
@@ -54,7 +54,7 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the import_ordering rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: zlinter.session.LintDocument,
+    doc: *zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {
@@ -146,7 +146,7 @@ fn deinitScopedImports(scoped_imports: *std.AutoArrayHashMap(Ast.Node.Index, Imp
 }
 
 fn swapNodesFix(
-    doc: zlinter.session.LintDocument,
+    doc: *zlinter.session.LintDocument,
     first: Ast.Node.Index,
     second: Ast.Node.Index,
     allocator: std.mem.Allocator,
@@ -179,7 +179,7 @@ fn swapNodesFix(
 
 /// Returns declarations initialised as imports grouped by their parent (i.e., their scope).
 fn resolveScopedImports(
-    doc: zlinter.session.LintDocument,
+    doc: *zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
 ) !std.AutoArrayHashMap(Ast.Node.Index, ImportsQueueLinesAscending) {
     const tree = doc.handle.tree;
@@ -261,7 +261,7 @@ fn classifyImportPath(path: []const u8) ImportDecl.Classification {
 
 // TODO(#52): Move to ast module
 // zlinter-disable-next-line
-// fn getScopedNode(doc: zlinter.session.LintDocument, node: Ast.Node.Index) Ast.Node.Index {
+// fn getScopedNode(doc: *zlinter.session.LintDocument, node: Ast.Node.Index) Ast.Node.Index {
 //     var parent = doc.lineage.items(.parent)[node];
 //     while (parent) |parent_node| {
 //         switch (shims.nodeTag(doc.handle.tree, parent_node)) {

--- a/src/rules/import_ordering.zig
+++ b/src/rules/import_ordering.zig
@@ -146,7 +146,7 @@ fn deinitScopedImports(scoped_imports: *std.AutoArrayHashMap(Ast.Node.Index, Imp
 }
 
 fn swapNodesFix(
-    doc: *zlinter.session.LintDocument,
+    doc: *const zlinter.session.LintDocument,
     first: Ast.Node.Index,
     second: Ast.Node.Index,
     allocator: std.mem.Allocator,
@@ -261,7 +261,7 @@ fn classifyImportPath(path: []const u8) ImportDecl.Classification {
 
 // TODO(#52): Move to ast module
 // zlinter-disable-next-line
-// fn getScopedNode(doc: *zlinter.session.LintDocument, node: Ast.Node.Index) Ast.Node.Index {
+// fn getScopedNode(doc: *const zlinter.session.LintDocument, node: Ast.Node.Index) Ast.Node.Index {
 //     var parent = doc.lineage.items(.parent)[node];
 //     while (parent) |parent_node| {
 //         switch (shims.nodeTag(doc.handle.tree, parent_node)) {

--- a/src/rules/import_ordering.zig
+++ b/src/rules/import_ordering.zig
@@ -54,7 +54,8 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the import_ordering rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: *zlinter.session.LintDocument,
+    _: *zlinter.session.LintContext,
+    doc: *const zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {
@@ -179,7 +180,7 @@ fn swapNodesFix(
 
 /// Returns declarations initialised as imports grouped by their parent (i.e., their scope).
 fn resolveScopedImports(
-    doc: *zlinter.session.LintDocument,
+    doc: *const zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
 ) !std.AutoArrayHashMap(Ast.Node.Index, ImportsQueueLinesAscending) {
     const tree = doc.handle.tree;

--- a/src/rules/max_positional_args.zig
+++ b/src/rules/max_positional_args.zig
@@ -42,7 +42,8 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the max_positional_args rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: *zlinter.session.LintDocument,
+    _: *zlinter.session.LintContext,
+    doc: *const zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {

--- a/src/rules/max_positional_args.zig
+++ b/src/rules/max_positional_args.zig
@@ -42,7 +42,7 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the max_positional_args rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: zlinter.session.LintDocument,
+    doc: *zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {

--- a/src/rules/no_comment_out_code.zig
+++ b/src/rules/no_comment_out_code.zig
@@ -42,7 +42,8 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the no_comment_out_code rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: *zlinter.session.LintDocument,
+    _: *zlinter.session.LintContext,
+    doc: *const zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {

--- a/src/rules/no_comment_out_code.zig
+++ b/src/rules/no_comment_out_code.zig
@@ -42,7 +42,7 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the no_comment_out_code rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: zlinter.session.LintDocument,
+    doc: *zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {

--- a/src/rules/no_deprecated.zig
+++ b/src/rules/no_deprecated.zig
@@ -24,7 +24,7 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the no_deprecated rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: zlinter.session.LintDocument,
+    doc: *zlinter.session.LintDocument,
     gpa: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {
@@ -153,19 +153,18 @@ fn handleIdentifierAccess(
     rule: zlinter.rules.LintRule,
     gpa: std.mem.Allocator,
     arena: std.mem.Allocator,
-    doc: zlinter.session.LintDocument,
+    doc: *zlinter.session.LintDocument,
     node_index: Ast.Node.Index,
     identifier_token: Ast.TokenIndex,
     lint_problems: *shims.ArrayList(zlinter.results.LintProblem),
     config: Config,
 ) !void {
     const handle = doc.handle;
-    const analyser = doc.analyser;
     const tree = doc.handle.tree;
 
     const source_index = handle.tree.tokens.items(.start)[identifier_token];
 
-    const decl_with_handle = (try analyser.lookupSymbolGlobal(
+    const decl_with_handle = (try doc.analyser.lookupSymbolGlobal(
         handle,
         tree.tokenSlice(identifier_token),
         source_index,
@@ -206,7 +205,7 @@ fn handleEnumLiteral(
     rule: zlinter.rules.LintRule,
     gpa: std.mem.Allocator,
     arena: std.mem.Allocator,
-    doc: zlinter.session.LintDocument,
+    doc: *zlinter.session.LintDocument,
     node_index: Ast.Node.Index,
     identifier_token: Ast.TokenIndex,
     lint_problems: *shims.ArrayList(zlinter.results.LintProblem),
@@ -232,7 +231,7 @@ fn handleEnumLiteral(
 }
 
 fn getSymbolEnumLiteral(
-    doc: zlinter.session.LintDocument,
+    doc: *zlinter.session.LintDocument,
     node: Ast.Node.Index,
     name: []const u8,
     gpa: std.mem.Allocator,
@@ -275,14 +274,13 @@ fn handleFieldAccess(
     rule: zlinter.rules.LintRule,
     gpa: std.mem.Allocator,
     arena: std.mem.Allocator,
-    doc: zlinter.session.LintDocument,
+    doc: *zlinter.session.LintDocument,
     node_index: Ast.Node.Index,
     identifier_token: Ast.TokenIndex,
     lint_problems: *shims.ArrayList(zlinter.results.LintProblem),
     config: Config,
 ) !void {
     const handle = doc.handle;
-    const analyser = doc.analyser;
     const tree = doc.handle.tree;
     const token_starts = handle.tree.tokens.items(.start);
 
@@ -296,7 +294,7 @@ fn handleFieldAccess(
         };
     };
 
-    if (try analyser.getSymbolFieldAccesses(
+    if (try doc.analyser.getSymbolFieldAccesses(
         arena,
         handle,
         token_starts[identifier_token],

--- a/src/rules/no_deprecated.zig
+++ b/src/rules/no_deprecated.zig
@@ -24,7 +24,8 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the no_deprecated rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: *zlinter.session.LintDocument,
+    context: *zlinter.session.LintContext,
+    doc: *const zlinter.session.LintDocument,
     gpa: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {
@@ -51,6 +52,7 @@ fn run(
                 rule,
                 gpa,
                 arena,
+                context,
                 doc,
                 node.toNodeIndex(),
                 shims.nodeMainToken(tree, node.toNodeIndex()),
@@ -61,6 +63,7 @@ fn run(
                 rule,
                 gpa,
                 arena,
+                context,
                 doc,
                 node.toNodeIndex(),
                 switch (zlinter.version.zig) {
@@ -74,6 +77,7 @@ fn run(
                 rule,
                 gpa,
                 arena,
+                context,
                 doc,
                 node.toNodeIndex(),
                 shims.nodeMainToken(tree, node.toNodeIndex()),
@@ -153,7 +157,8 @@ fn handleIdentifierAccess(
     rule: zlinter.rules.LintRule,
     gpa: std.mem.Allocator,
     arena: std.mem.Allocator,
-    doc: *zlinter.session.LintDocument,
+    context: *zlinter.session.LintContext,
+    doc: *const zlinter.session.LintDocument,
     node_index: Ast.Node.Index,
     identifier_token: Ast.TokenIndex,
     lint_problems: *shims.ArrayList(zlinter.results.LintProblem),
@@ -164,7 +169,7 @@ fn handleIdentifierAccess(
 
     const source_index = handle.tree.tokens.items(.start)[identifier_token];
 
-    const decl_with_handle = (try doc.analyser.lookupSymbolGlobal(
+    const decl_with_handle = (try context.analyser.lookupSymbolGlobal(
         handle,
         tree.tokenSlice(identifier_token),
         source_index,
@@ -205,13 +210,15 @@ fn handleEnumLiteral(
     rule: zlinter.rules.LintRule,
     gpa: std.mem.Allocator,
     arena: std.mem.Allocator,
-    doc: *zlinter.session.LintDocument,
+    context: *zlinter.session.LintContext,
+    doc: *const zlinter.session.LintDocument,
     node_index: Ast.Node.Index,
     identifier_token: Ast.TokenIndex,
     lint_problems: *shims.ArrayList(zlinter.results.LintProblem),
     config: Config,
 ) !void {
     const decl_with_handle = try getSymbolEnumLiteral(
+        context,
         doc,
         node_index,
         doc.handle.tree.tokenSlice(identifier_token),
@@ -231,7 +238,8 @@ fn handleEnumLiteral(
 }
 
 fn getSymbolEnumLiteral(
-    doc: *zlinter.session.LintDocument,
+    context: *zlinter.session.LintContext,
+    doc: *const zlinter.session.LintDocument,
     node: Ast.Node.Index,
     name: []const u8,
     gpa: std.mem.Allocator,
@@ -256,12 +264,12 @@ fn getSymbolEnumLiteral(
     }
 
     return switch (zlinter.version.zig) {
-        .@"0.14" => doc.analyser.lookupSymbolFieldInit(
+        .@"0.14" => context.analyser.lookupSymbolFieldInit(
             doc.handle,
             name,
             ancestors.items[0..],
         ),
-        .@"0.15", .@"0.16" => doc.analyser.lookupSymbolFieldInit(
+        .@"0.15", .@"0.16" => context.analyser.lookupSymbolFieldInit(
             doc.handle,
             name,
             ancestors.items[0],
@@ -274,7 +282,8 @@ fn handleFieldAccess(
     rule: zlinter.rules.LintRule,
     gpa: std.mem.Allocator,
     arena: std.mem.Allocator,
-    doc: *zlinter.session.LintDocument,
+    context: *zlinter.session.LintContext,
+    doc: *const zlinter.session.LintDocument,
     node_index: Ast.Node.Index,
     identifier_token: Ast.TokenIndex,
     lint_problems: *shims.ArrayList(zlinter.results.LintProblem),
@@ -294,7 +303,7 @@ fn handleFieldAccess(
         };
     };
 
-    if (try doc.analyser.getSymbolFieldAccesses(
+    if (try context.analyser.getSymbolFieldAccesses(
         arena,
         handle,
         token_starts[identifier_token],

--- a/src/rules/no_empty_block.zig
+++ b/src/rules/no_empty_block.zig
@@ -62,7 +62,8 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the no_empty_block rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: *zlinter.session.LintDocument,
+    _: *zlinter.session.LintContext,
+    doc: *const zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {

--- a/src/rules/no_empty_block.zig
+++ b/src/rules/no_empty_block.zig
@@ -62,7 +62,7 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the no_empty_block rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: zlinter.session.LintDocument,
+    doc: *zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {

--- a/src/rules/no_hidden_allocations.zig
+++ b/src/rules/no_hidden_allocations.zig
@@ -50,7 +50,8 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the no_hidden_allocations rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: *zlinter.session.LintDocument,
+    context: *zlinter.session.LintContext,
+    doc: *const zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {
@@ -97,7 +98,7 @@ fn run(
         if (!is_allocator_method) continue :nodes;
 
         const decl_name, const uri = decl_name_and_uri: {
-            if (try doc.analyser.resolveVarDeclAlias(switch (zlinter.version.zig) {
+            if (try context.analyser.resolveVarDeclAlias(switch (zlinter.version.zig) {
                 .@"0.14" => .{ .node = lhs, .handle = doc.handle },
                 .@"0.15", .@"0.16" => .{ .node_handle = .{ .node = lhs, .handle = doc.handle }, .container_type = null },
             })) |decl_handle| {

--- a/src/rules/no_hidden_allocations.zig
+++ b/src/rules/no_hidden_allocations.zig
@@ -50,7 +50,7 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the no_hidden_allocations rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: zlinter.session.LintDocument,
+    doc: *zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {

--- a/src/rules/no_inferred_error_unions.zig
+++ b/src/rules/no_inferred_error_unions.zig
@@ -37,7 +37,7 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the no_inferred_error_unions rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: zlinter.session.LintDocument,
+    doc: *zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {

--- a/src/rules/no_inferred_error_unions.zig
+++ b/src/rules/no_inferred_error_unions.zig
@@ -37,7 +37,8 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the no_inferred_error_unions rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: *zlinter.session.LintDocument,
+    _: *zlinter.session.LintContext,
+    doc: *const zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {

--- a/src/rules/no_literal_args.zig
+++ b/src/rules/no_literal_args.zig
@@ -58,7 +58,8 @@ const LiteralKind = enum { bool, string, number, char };
 /// Runs the no_literal_args rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: *zlinter.session.LintDocument,
+    _: *zlinter.session.LintContext,
+    doc: *const zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {

--- a/src/rules/no_literal_args.zig
+++ b/src/rules/no_literal_args.zig
@@ -58,7 +58,7 @@ const LiteralKind = enum { bool, string, number, char };
 /// Runs the no_literal_args rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: zlinter.session.LintDocument,
+    doc: *zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {

--- a/src/rules/no_literal_only_bool_expression.zig
+++ b/src/rules/no_literal_only_bool_expression.zig
@@ -42,7 +42,7 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the no_literal_only_bool_expression rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: zlinter.session.LintDocument,
+    doc: *zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {

--- a/src/rules/no_literal_only_bool_expression.zig
+++ b/src/rules/no_literal_only_bool_expression.zig
@@ -42,7 +42,8 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the no_literal_only_bool_expression rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: *zlinter.session.LintDocument,
+    _: *zlinter.session.LintContext,
+    doc: *const zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {

--- a/src/rules/no_orelse_unreachable.zig
+++ b/src/rules/no_orelse_unreachable.zig
@@ -22,7 +22,7 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the no_orelse_unreachable rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: zlinter.session.LintDocument,
+    doc: *zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {

--- a/src/rules/no_orelse_unreachable.zig
+++ b/src/rules/no_orelse_unreachable.zig
@@ -22,7 +22,8 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the no_orelse_unreachable rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: *zlinter.session.LintDocument,
+    _: *zlinter.session.LintContext,
+    doc: *const zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {

--- a/src/rules/no_panic.zig
+++ b/src/rules/no_panic.zig
@@ -63,7 +63,8 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the no_panic rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: *zlinter.session.LintDocument,
+    _: *zlinter.session.LintContext,
+    doc: *const zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {

--- a/src/rules/no_panic.zig
+++ b/src/rules/no_panic.zig
@@ -63,7 +63,7 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the no_panic rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: zlinter.session.LintDocument,
+    doc: *zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {

--- a/src/rules/no_swallow_error.zig
+++ b/src/rules/no_swallow_error.zig
@@ -33,7 +33,8 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the no_swallow_error rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: *zlinter.session.LintDocument,
+    _: *zlinter.session.LintContext,
+    doc: *const zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {

--- a/src/rules/no_swallow_error.zig
+++ b/src/rules/no_swallow_error.zig
@@ -33,7 +33,7 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the no_swallow_error rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: zlinter.session.LintDocument,
+    doc: *zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {

--- a/src/rules/no_todo.zig
+++ b/src/rules/no_todo.zig
@@ -35,7 +35,7 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the no_todo rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: zlinter.session.LintDocument,
+    doc: *zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {

--- a/src/rules/no_todo.zig
+++ b/src/rules/no_todo.zig
@@ -35,7 +35,8 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the no_todo rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: *zlinter.session.LintDocument,
+    _: *zlinter.session.LintContext,
+    doc: *const zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {

--- a/src/rules/no_undefined.zig
+++ b/src/rules/no_undefined.zig
@@ -41,7 +41,8 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the no_undefined rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: *zlinter.session.LintDocument,
+    _: *zlinter.session.LintContext,
+    doc: *const zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {

--- a/src/rules/no_undefined.zig
+++ b/src/rules/no_undefined.zig
@@ -41,7 +41,7 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the no_undefined rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: zlinter.session.LintDocument,
+    doc: *zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {

--- a/src/rules/no_unused.zig
+++ b/src/rules/no_unused.zig
@@ -23,7 +23,8 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the no_unused rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: *zlinter.session.LintDocument,
+    context: *zlinter.session.LintContext,
+    doc: *const zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {
@@ -47,7 +48,7 @@ fn run(
         while (node.index < tree.nodes.len) : (node.index += 1) {
             switch (shims.nodeTag(tree, node.toNodeIndex())) {
                 .identifier => try map.put(allocator, tree.tokenSlice(shims.nodeMainToken(tree, node.toNodeIndex())), {}),
-                .field_access => if (try isFieldAccessOfRootContainer(doc, node.toNodeIndex())) {
+                .field_access => if (try isFieldAccessOfRootContainer(context, doc, node.toNodeIndex())) {
                     const node_data = shims.nodeData(tree, node.toNodeIndex());
                     try map.put(allocator, tree.tokenSlice(switch (zlinter.version.zig) {
                         .@"0.14" => node_data.rhs,
@@ -150,7 +151,11 @@ fn namedFnDeclProto(
     return null;
 }
 
-fn isFieldAccessOfRootContainer(doc: *zlinter.session.LintDocument, node: Ast.Node.Index) error{OutOfMemory}!bool {
+fn isFieldAccessOfRootContainer(
+    context: *zlinter.session.LintContext,
+    doc: *const zlinter.session.LintDocument,
+    node: Ast.Node.Index,
+) error{OutOfMemory}!bool {
     std.debug.assert(shims.nodeTag(doc.handle.tree, node) == .field_access);
 
     const tree = doc.handle.tree;
@@ -161,7 +166,7 @@ fn isFieldAccessOfRootContainer(doc: *zlinter.session.LintDocument, node: Ast.No
         .@"0.15", .@"0.16" => node_data.node_and_token.@"0",
     };
 
-    if (try doc.resolveTypeOfNode(lhs)) |t| {
+    if (try context.resolveTypeOfNode(doc, lhs)) |t| {
         switch (t.resolveDeclLiteralResultType().data) {
             .container => |scope_handle| return isContainerRoot(scope_handle),
             else => {},

--- a/src/rules/no_unused.zig
+++ b/src/rules/no_unused.zig
@@ -23,7 +23,7 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the no_unused rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: zlinter.session.LintDocument,
+    doc: *zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {
@@ -150,7 +150,7 @@ fn namedFnDeclProto(
     return null;
 }
 
-fn isFieldAccessOfRootContainer(doc: zlinter.session.LintDocument, node: Ast.Node.Index) error{OutOfMemory}!bool {
+fn isFieldAccessOfRootContainer(doc: *zlinter.session.LintDocument, node: Ast.Node.Index) error{OutOfMemory}!bool {
     std.debug.assert(shims.nodeTag(doc.handle.tree, node) == .field_access);
 
     const tree = doc.handle.tree;

--- a/src/rules/require_braces.zig
+++ b/src/rules/require_braces.zig
@@ -98,7 +98,8 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the require_braces rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: *zlinter.session.LintDocument,
+    _: *zlinter.session.LintContext,
+    doc: *const zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {

--- a/src/rules/require_braces.zig
+++ b/src/rules/require_braces.zig
@@ -98,7 +98,7 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the require_braces rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: zlinter.session.LintDocument,
+    doc: *zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {

--- a/src/rules/require_doc_comment.zig
+++ b/src/rules/require_doc_comment.zig
@@ -29,7 +29,8 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the require_doc_comment rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: *zlinter.session.LintDocument,
+    _: *zlinter.session.LintContext,
+    doc: *const zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {

--- a/src/rules/require_doc_comment.zig
+++ b/src/rules/require_doc_comment.zig
@@ -29,7 +29,7 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the require_doc_comment rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: zlinter.session.LintDocument,
+    doc: *zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {

--- a/src/rules/require_errdefer_dealloc.zig
+++ b/src/rules/require_errdefer_dealloc.zig
@@ -289,7 +289,7 @@ fn declRequiringCleanup(doc: *zlinter.session.LintDocument, maybe_var_decl_node:
 ///
 /// Where as `.init(allocator)` or `.init(std.heap.c_allocator)` should be checked
 /// for stricter cleanup on error as it won't automatically clear itself.
-fn hasNonFreeingAllocatorParam(doc: *zlinter.session.LintDocument, params: []const Ast.Node.Index) bool {
+fn hasNonFreeingAllocatorParam(doc: *const zlinter.session.LintDocument, params: []const Ast.Node.Index) bool {
     const tree = doc.handle.tree;
     const skip_var_and_field_names: []const []const u8 = &.{
         "arena",

--- a/src/rules/require_errdefer_dealloc.zig
+++ b/src/rules/require_errdefer_dealloc.zig
@@ -407,14 +407,13 @@ test "hasNonFreeingAllocatorParam" {
         var tmp = std.testing.tmpDir(.{});
         defer tmp.cleanup();
 
-        var doc = try zlinter.testing.loadFakeDocument(
+        const doc = try zlinter.testing.loadFakeDocument(
             &context,
             tmp.dir,
             "test.zig",
             "fn main() void {\n" ++ source ++ "\n}",
             arena.allocator(),
         );
-        _ = &doc;
 
         const tree = doc.handle.tree;
         const actual = hasNonFreeingAllocatorParam(

--- a/src/rules/require_errdefer_dealloc.zig
+++ b/src/rules/require_errdefer_dealloc.zig
@@ -60,7 +60,8 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the require_errdefer_dealloc rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: *zlinter.session.LintDocument,
+    context: *zlinter.session.LintContext,
+    doc: *const zlinter.session.LintDocument,
     gpa: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {
@@ -96,6 +97,7 @@ fn run(
             continue :nodes;
 
         try processBlock(
+            context,
             doc,
             fn_decl.block,
             &problem_nodes,
@@ -130,7 +132,8 @@ fn run(
 }
 
 fn processBlock(
-    doc: *zlinter.session.LintDocument,
+    context: *zlinter.session.LintContext,
+    doc: *const zlinter.session.LintDocument,
     block_node: Ast.Node.Index,
     problems: *shims.ArrayList(Ast.Node.Index),
     gpa: std.mem.Allocator,
@@ -144,7 +147,7 @@ fn processBlock(
     var call_buffer: [1]Ast.Node.Index = undefined;
 
     for (doc.lineage.items(.children)[NodeIndexShim.init(block_node).index] orelse &.{}) |child_node| {
-        if (try declRequiringCleanup(doc, child_node)) |decl_ref| {
+        if (try declRequiringCleanup(context, doc, child_node)) |decl_ref| {
             try cleanup_symbols.put(
                 try arena.dupe(u8, doc.handle.tree.tokenSlice(decl_ref.decl_name_token)),
                 child_node,
@@ -172,6 +175,7 @@ fn processBlock(
             }
         } else if (zlinter.ast.isBlock(tree, child_node)) {
             try processBlock(
+                context,
                 doc,
                 child_node,
                 problems,
@@ -193,7 +197,11 @@ const DeclRef = struct {
 
 /// Returns a declaration reference if the given node is a declaration node
 /// that looks like it needs to be cleaned up (e.g., if it has a `deinit` method)
-fn declRequiringCleanup(doc: *zlinter.session.LintDocument, maybe_var_decl_node: Ast.Node.Index) !?DeclRef {
+fn declRequiringCleanup(
+    context: *zlinter.session.LintContext,
+    doc: *const zlinter.session.LintDocument,
+    maybe_var_decl_node: Ast.Node.Index,
+) !?DeclRef {
     const tree = doc.handle.tree;
     const var_decl = tree.fullVarDecl(maybe_var_decl_node) orelse return null;
     const init_node = (NodeIndexShim.initOptional(var_decl.ast.init_node) orelse
@@ -231,7 +239,7 @@ fn declRequiringCleanup(doc: *zlinter.session.LintDocument, maybe_var_decl_node:
             false,
     }) return null;
 
-    const var_decl_type = try doc.resolveTypeOfNode(maybe_var_decl_node) orelse return null;
+    const var_decl_type = try context.resolveTypeOfNode(doc, maybe_var_decl_node) orelse return null;
     switch (var_decl_type.data) {
         .container => |container| {
             const scope_handle = switch (zlinter.version.zig) {
@@ -392,25 +400,25 @@ test "hasNonFreeingAllocatorParam" {
 
         defer _ = arena.reset(.retain_capacity);
 
-        var ctx: zlinter.session.LintContext = undefined;
-        try ctx.init(.{}, std.testing.allocator);
-        defer ctx.deinit();
+        var context: zlinter.session.LintContext = undefined;
+        try context.init(.{}, std.testing.allocator, arena.allocator());
+        defer context.deinit();
 
         var tmp = std.testing.tmpDir(.{});
         defer tmp.cleanup();
 
         var doc = try zlinter.testing.loadFakeDocument(
-            &ctx,
+            &context,
             tmp.dir,
             "test.zig",
             "fn main() void {\n" ++ source ++ "\n}",
             arena.allocator(),
         );
-        defer doc.deinit(ctx.gpa);
+        _ = &doc;
 
         const tree = doc.handle.tree;
         const actual = hasNonFreeingAllocatorParam(
-            &doc,
+            doc,
             tree.fullCall(&buffer, try zlinter.testing.expectNodeOfTagFirst(
                 doc,
                 &.{

--- a/src/rules/require_errdefer_dealloc.zig
+++ b/src/rules/require_errdefer_dealloc.zig
@@ -60,7 +60,7 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the require_errdefer_dealloc rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: zlinter.session.LintDocument,
+    doc: *zlinter.session.LintDocument,
     gpa: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {
@@ -130,7 +130,7 @@ fn run(
 }
 
 fn processBlock(
-    doc: zlinter.session.LintDocument,
+    doc: *zlinter.session.LintDocument,
     block_node: Ast.Node.Index,
     problems: *shims.ArrayList(Ast.Node.Index),
     gpa: std.mem.Allocator,
@@ -193,7 +193,7 @@ const DeclRef = struct {
 
 /// Returns a declaration reference if the given node is a declaration node
 /// that looks like it needs to be cleaned up (e.g., if it has a `deinit` method)
-fn declRequiringCleanup(doc: zlinter.session.LintDocument, maybe_var_decl_node: Ast.Node.Index) !?DeclRef {
+fn declRequiringCleanup(doc: *zlinter.session.LintDocument, maybe_var_decl_node: Ast.Node.Index) !?DeclRef {
     const tree = doc.handle.tree;
     const var_decl = tree.fullVarDecl(maybe_var_decl_node) orelse return null;
     const init_node = (NodeIndexShim.initOptional(var_decl.ast.init_node) orelse
@@ -289,7 +289,7 @@ fn declRequiringCleanup(doc: zlinter.session.LintDocument, maybe_var_decl_node: 
 ///
 /// Where as `.init(allocator)` or `.init(std.heap.c_allocator)` should be checked
 /// for stricter cleanup on error as it won't automatically clear itself.
-fn hasNonFreeingAllocatorParam(doc: zlinter.session.LintDocument, params: []const Ast.Node.Index) bool {
+fn hasNonFreeingAllocatorParam(doc: *zlinter.session.LintDocument, params: []const Ast.Node.Index) bool {
     const tree = doc.handle.tree;
     const skip_var_and_field_names: []const []const u8 = &.{
         "arena",
@@ -410,7 +410,7 @@ test "hasNonFreeingAllocatorParam" {
 
         const tree = doc.handle.tree;
         const actual = hasNonFreeingAllocatorParam(
-            doc,
+            &doc,
             tree.fullCall(&buffer, try zlinter.testing.expectNodeOfTagFirst(
                 doc,
                 &.{

--- a/src/rules/switch_case_ordering.zig
+++ b/src/rules/switch_case_ordering.zig
@@ -19,7 +19,8 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the switch_case_ordering rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: *zlinter.session.LintDocument,
+    _: *zlinter.session.LintContext,
+    doc: *const zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {

--- a/src/rules/switch_case_ordering.zig
+++ b/src/rules/switch_case_ordering.zig
@@ -19,7 +19,7 @@ pub fn buildRule(options: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
 /// Runs the switch_case_ordering rule.
 fn run(
     rule: zlinter.rules.LintRule,
-    doc: zlinter.session.LintDocument,
+    doc: *zlinter.session.LintDocument,
     allocator: std.mem.Allocator,
     options: zlinter.rules.RunOptions,
 ) error{OutOfMemory}!?zlinter.results.LintResult {


### PR DESCRIPTION
This avoids confusion around shallow copies and mutability as it was mutating what the pointers in the shallow copies were pointing to. 

This is breaking in that run accepts a pointer and context is re-introduced.

Before:

```zig
fn (
    self: LintRule,
    doc: session.LintDocument,
    gpa: std.mem.Allocator,
    options: RunOptions,
) error{OutOfMemory}!?results.LintResult
```

After:

```zig
fn (
    self: LintRule,
    context: *session.LintContext,
    doc: *const session.LintDocument,
    gpa: std.mem.Allocator,
    options: RunOptions,
 ) error{OutOfMemory}!?results.LintResult
```