### PR TITLE
Fix: Coverage timing out on master

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -40,6 +40,9 @@ jobs:
 
       - name: "Prefetch dependencies (workaround)"
         run: sed -n 's/.*url *= *"\(.*\)".*/\1/p' build.zig.zon | xargs -t -n1 zig fetch
+      
+      - name: "Prefetch ZLS dependencies (workaround)"
+        run: curl -L https://raw.githubusercontent.com/zigtools/zls/7b9d079c65e2400612bd126ee64ffda5dbb7e1f6/build.zig.zon | sed -n 's/.*url *= *"\(.*\)".*/\1/p' | xargs -t -n1 zig fetch
 
       - name: "Run unit tests with coverage"
         run: |

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -6,6 +6,7 @@
     .dependencies = .{
         .zls = .{
             // Update with `zig fetch --save git+https://github.com/zigtools/zls#master`
+            // IF changed THEN update .github/coverage.yml
             .url = "git+https://github.com/zigtools/zls?ref=master#7b9d079c65e2400612bd126ee64ffda5dbb7e1f6",
             .hash = "zls-0.16.0-dev-rmm5foGXJAD1rjBpZk8_YcjFuPLNXCOYbyykqtfSRHlN",
         },


### PR DESCRIPTION
Seems that it's getting stuck on dependencies, so temporarily just going to manually fetch all dependencies (zls) and transitive dependencies. It's a bit of a hack, if we need to do this long term, maybe worth trying to upstream a fix to `zig build --fetch` to also fetch transitive dependencies.