### PR TITLE
Add `no_redundant_comptime` lint rule

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -737,6 +737,35 @@ pub fn divide(x: i32, y: i32) !i32 {
 
   * **Default:** `&.{}`
 
+## `no_redundant_comptime`
+
+Flags redundant `comptime` on parameters whose types are always comptime-known.
+
+In Zig, parameters of type `type`, `comptime_int`, and `comptime_float` are always comptime. 
+Writing `comptime T: type` is equivalent to `T: type`.
+
+**Good:**
+
+```zig
+fn List(T: type) type { ... }
+fn add(a: comptime_int, b: comptime_int) comptime_int { ... }
+```
+
+**Bad:**
+
+```zig
+fn List(comptime T: type) type { ... }
+fn add(comptime a: comptime_int, comptime b: comptime_int) comptime_int { ... }
+```
+
+**Config options:**
+
+* `severity`
+
+  * The severity (off, warning, error).
+
+  * **Default:** `.warning`
+
 ## `no_swallow_error`
 
 Disallow silently swallowing errors without proper handling or logging.

--- a/build.zig
+++ b/build.zig
@@ -30,6 +30,7 @@ pub const BuiltinLintRule = enum {
     no_literal_args,
     no_swallow_error,
     no_panic,
+    no_redundant_comptime,
     require_exhaustive_enum_switch,
     require_braces,
     require_doc_comment,
@@ -428,6 +429,7 @@ pub fn build(b: *std.Build) void {
                 buildBuiltinRule(b, .no_comment_out_code, .{ .target = target, .optimize = optimize, .zlinter_import = zlinter_import }, .{}),
                 buildBuiltinRule(b, .no_todo, .{ .target = target, .optimize = optimize, .zlinter_import = zlinter_import }, .{}),
                 buildBuiltinRule(b, .no_panic, .{ .target = target, .optimize = optimize, .zlinter_import = zlinter_import }, .{}),
+                buildBuiltinRule(b, .no_redundant_comptime, .{ .target = target, .optimize = optimize, .zlinter_import = zlinter_import }, .{}),
                 buildBuiltinRule(b, .max_positional_args, .{ .target = target, .optimize = optimize, .zlinter_import = zlinter_import }, .{}),
                 buildBuiltinRule(
                     b,

--- a/integration_tests/test_cases/no_redundant_comptime/no_redundant_comptime.input.zig
+++ b/integration_tests/test_cases/no_redundant_comptime/no_redundant_comptime.input.zig
@@ -1,0 +1,33 @@
+fn GoodList(T: type) type {
+    _ = T;
+    return struct {};
+}
+
+fn BadList(comptime T: type) type {
+    _ = T;
+    return struct {};
+}
+
+fn good(comptime n: usize) void {
+    _ = n;
+}
+
+fn bad(comptime a: comptime_int) comptime_int {
+    return a;
+}
+
+fn alsobad(comptime x: comptime_float) comptime_float {
+    return x;
+}
+
+fn fine(comptime allocator: std.mem.Allocator) void {
+    _ = allocator;
+}
+
+fn mixed(comptime T: type, n: usize, comptime F: comptime_float) void {
+    _ = T;
+    _ = n;
+    _ = F;
+}
+
+const std = @import("std");

--- a/integration_tests/test_cases/no_redundant_comptime/no_redundant_comptime.lint_expected.stdout
+++ b/integration_tests/test_cases/no_redundant_comptime/no_redundant_comptime.lint_expected.stdout
@@ -1,0 +1,26 @@
+warning Redundant `comptime` on parameter of type `type` - parameters of this type are always comptime [test_cases/no_redundant_comptime/no_redundant_comptime.input.zig:6:12] no_redundant_comptime
+
+ 6 | fn BadList(comptime T: type) type {
+   |            ^^^^^^^^^^^^^^^^
+
+warning Redundant `comptime` on parameter of type `comptime_int` - parameters of this type are always comptime [test_cases/no_redundant_comptime/no_redundant_comptime.input.zig:15:8] no_redundant_comptime
+
+ 15 | fn bad(comptime a: comptime_int) comptime_int {
+    |        ^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning Redundant `comptime` on parameter of type `comptime_float` - parameters of this type are always comptime [test_cases/no_redundant_comptime/no_redundant_comptime.input.zig:19:12] no_redundant_comptime
+
+ 19 | fn alsobad(comptime x: comptime_float) comptime_float {
+    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning Redundant `comptime` on parameter of type `type` - parameters of this type are always comptime [test_cases/no_redundant_comptime/no_redundant_comptime.input.zig:27:10] no_redundant_comptime
+
+ 27 | fn mixed(comptime T: type, n: usize, comptime F: comptime_float) void {
+    |          ^^^^^^^^^^^^^^^^
+
+warning Redundant `comptime` on parameter of type `comptime_float` - parameters of this type are always comptime [test_cases/no_redundant_comptime/no_redundant_comptime.input.zig:27:38] no_redundant_comptime
+
+ 27 | fn mixed(comptime T: type, n: usize, comptime F: comptime_float) void {
+    |                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+x 5 warnings

--- a/src/rules/no_redundant_comptime.zig
+++ b/src/rules/no_redundant_comptime.zig
@@ -1,0 +1,231 @@
+//! Flags redundant `comptime` on parameters whose types are always comptime-known.
+//!
+//! In Zig, parameters of type `type`, `comptime_int`, and `comptime_float` are always comptime.
+//! Writing `comptime T: type` is equivalent to `T: type`.
+//!
+//! **Good:**
+//!
+//! ```zig
+//! fn List(T: type) type { ... }
+//! fn add(a: comptime_int, b: comptime_int) comptime_int { ... }
+//! ```
+//!
+//! **Bad:**
+//!
+//! ```zig
+//! fn List(comptime T: type) type { ... }
+//! fn add(comptime a: comptime_int, comptime b: comptime_int) comptime_int { ... }
+//! ```
+//!
+
+/// Config for no_redundant_comptime rule.
+pub const Config = struct {
+    /// The severity (off, warning, error).
+    severity: zlinter.rules.LintProblemSeverity = .warning,
+};
+
+/// Builds and returns the no_redundant_comptime rule.
+pub fn buildRule(_: zlinter.rules.RuleOptions) zlinter.rules.LintRule {
+    return zlinter.rules.LintRule{
+        .rule_id = @tagName(.no_redundant_comptime),
+        .run = &run,
+    };
+}
+
+const redundant_types = [_][]const u8{
+    "type",
+    "comptime_int",
+    "comptime_float",
+};
+
+fn isRedundantComptimeType(tree: Ast, type_expr: Ast.Node.Index) bool {
+    if (tree.nodeTag(type_expr) != .identifier) return false;
+    const slice = tree.tokenSlice(tree.firstToken(type_expr));
+    for (redundant_types) |t| {
+        if (std.mem.eql(u8, slice, t)) return true;
+    }
+    return false;
+}
+
+/// Runs the no_redundant_comptime rule.
+fn run(
+    rule: zlinter.rules.LintRule,
+    _: *zlinter.session.LintContext,
+    doc: *const zlinter.session.LintDocument,
+    gpa: std.mem.Allocator,
+    options: zlinter.rules.RunOptions,
+) zlinter.rules.RunError!?zlinter.results.LintResult {
+    const config = options.getConfig(Config);
+    if (config.severity == .off) return null;
+
+    var lint_problems = std.ArrayList(zlinter.results.LintProblem).empty;
+    defer lint_problems.deinit(gpa);
+
+    const tree = doc.handle.tree;
+    var fn_buffer: [1]Ast.Node.Index = undefined;
+
+    var index: u32 = 1;
+    while (index < tree.nodes.len) : (index += 1) {
+        const node: Ast.Node.Index = @enumFromInt(index);
+
+        const fn_proto = switch (tree.nodeTag(node)) {
+            .fn_proto => tree.fnProto(node),
+            .fn_proto_multi => tree.fnProtoMulti(node),
+            .fn_proto_one => tree.fnProtoOne(&fn_buffer, node),
+            .fn_proto_simple => tree.fnProtoSimple(&fn_buffer, node),
+            else => null,
+        } orelse continue;
+
+        var param_it = fn_proto.iterate(&tree);
+        while (param_it.next()) |param| {
+            const comptime_token = param.comptime_noalias orelse continue;
+            if (tree.tokenTag(comptime_token) != .keyword_comptime) continue;
+
+            const type_node = param.type_expr orelse continue;
+            if (!isRedundantComptimeType(tree, type_node)) continue;
+
+            const type_slice = tree.tokenSlice(tree.firstToken(type_node));
+            try lint_problems.append(gpa, .{
+                .rule_id = rule.rule_id,
+                .severity = config.severity,
+                .start = .startOfToken(tree, comptime_token),
+                .end = .endOfToken(tree, tree.lastToken(type_node)),
+                .message = try std.fmt.allocPrint(
+                    gpa,
+                    "Redundant `comptime` on parameter of type `{s}` - parameters of this type are always comptime",
+                    .{type_slice},
+                ),
+            });
+        }
+    }
+
+    return if (lint_problems.items.len > 0)
+        try zlinter.results.LintResult.init(
+            gpa,
+            doc.path,
+            try lint_problems.toOwnedSlice(gpa),
+        )
+    else
+        null;
+}
+
+test "no_redundant_comptime" {
+    std.testing.refAllDecls(@This());
+
+    const rule = buildRule(.{});
+
+    // Bad: redundant comptime on type parameter
+    try zlinter.testing.testRunRule(
+        rule,
+        \\fn List(comptime T: type) type {
+        \\    return struct {};
+        \\}
+    ,
+        .{},
+        Config{},
+        &.{
+            .{
+                .rule_id = "no_redundant_comptime",
+                .severity = .warning,
+                .slice = "comptime T: type",
+                .message = "Redundant `comptime` on parameter of type `type` - parameters of this type are always comptime",
+            },
+        },
+    );
+
+    // Bad: redundant comptime on comptime_int
+    try zlinter.testing.testRunRule(
+        rule,
+        \\fn add(comptime a: comptime_int, comptime b: comptime_int) comptime_int {
+        \\    return a + b;
+        \\}
+    ,
+        .{},
+        Config{},
+        &.{
+            .{
+                .rule_id = "no_redundant_comptime",
+                .severity = .warning,
+                .slice = "comptime a: comptime_int",
+                .message = "Redundant `comptime` on parameter of type `comptime_int` - parameters of this type are always comptime",
+            },
+            .{
+                .rule_id = "no_redundant_comptime",
+                .severity = .warning,
+                .slice = "comptime b: comptime_int",
+                .message = "Redundant `comptime` on parameter of type `comptime_int` - parameters of this type are always comptime",
+            },
+        },
+    );
+
+    // Bad: two redundant comptime params separated by a non-comptime param
+    try zlinter.testing.testRunRule(
+        rule,
+        \\fn mixed(comptime T: type, n: usize, comptime F: comptime_float) void {}
+    ,
+        .{},
+        Config{},
+        &.{
+            .{
+                .rule_id = "no_redundant_comptime",
+                .severity = .warning,
+                .slice = "comptime T: type",
+                .message = "Redundant `comptime` on parameter of type `type` - parameters of this type are always comptime",
+            },
+            .{
+                .rule_id = "no_redundant_comptime",
+                .severity = .warning,
+                .slice = "comptime F: comptime_float",
+                .message = "Redundant `comptime` on parameter of type `comptime_float` - parameters of this type are always comptime",
+            },
+        },
+    );
+
+    // Good: comptime on @TypeOf (not inherently comptime)
+    try zlinter.testing.testRunRule(
+        rule,
+        \\fn wrap(comptime x: @TypeOf(some_val)) void {}
+    ,
+        .{},
+        Config{},
+        &.{},
+    );
+
+    // Good: comptime on non-comptime types
+    try zlinter.testing.testRunRule(
+        rule,
+        \\fn foo(comptime n: usize) void {}
+    ,
+        .{},
+        Config{},
+        &.{},
+    );
+
+    // Good: no comptime keyword
+    try zlinter.testing.testRunRule(
+        rule,
+        \\fn List(T: type) type {
+        \\    return struct {};
+        \\}
+    ,
+        .{},
+        Config{},
+        &.{},
+    );
+
+    // Off severity
+    try zlinter.testing.testRunRule(
+        rule,
+        \\fn List(comptime T: type) type {
+        \\    return struct {};
+        \\}
+    ,
+        .{},
+        Config{ .severity = .off },
+        &.{},
+    );
+}
+
+const std = @import("std");
+const zlinter = @import("zlinter");
+const Ast = std.zig.Ast;


### PR DESCRIPTION
I created a lint rule that may be of interest to others so I figured I'd share it here.

The Zig compiler already catches a few forms of redundant `comptime` keyword, but it's mainly in `comptime` blocks. 

`no_redundant_comptime` catches the additional case where the compiler currently doesn't flag `comptime` on types that are `comptime` only like `type`, `comptime_int`, and `comptime_float`. I figured this was in the spirit of the project since https://ziglang.org/documentation/master/#Style-Guide mentions removing redundancy in other places as well. 

Thanks for the great linter!