### PR TITLE
Use latest setup-zig v2 instead of locked version #134

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: "Setup zig environment"
-        uses: mlugg/setup-zig@v2.0.5
+        uses: mlugg/setup-zig@v2
         with:
           version: master
       

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
       - name: "Checkout repo"
         uses: actions/checkout@v4
       - name: "Setup zig environment"
-        uses: mlugg/setup-zig@v2.0.5
+        uses: mlugg/setup-zig@v2
         with:
           version: master
       - name: "Run build website"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,7 +24,7 @@ jobs:
       - name: "Checkout repo"
         uses: actions/checkout@v4
       - name: "Setup zig environment"
-        uses: mlugg/setup-zig@v2.0.5
+        uses: mlugg/setup-zig@v2
         with:
           version: master
       - name: "Run unit tests"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,7 +24,7 @@ jobs:
       - name: "Checkout repo"
         uses: actions/checkout@v4
       - name: "Setup zig environment"
-        uses: mlugg/setup-zig@v2.0.5
+        uses: mlugg/setup-zig@v2
         with:
           version: master
       - name: "Run unit tests"


### PR DESCRIPTION
Mostly seeing if the CI issues have worked themselves out since removing ZLS dep and prefetching logic.