### PR TITLE
Introduce `addCompileUnit` to limit lint compiled context and a bunch of caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,20 @@ If your project is large it may be worth setting optimize to `.ReleaseFast`. Jus
 
 Since 0.16.x, `.Debug` is significantly slower to run as it uses the debug allocator. Unless you're working on zlinter or a custom rule, it should be avoided.
 
+### Limit Compile Units
+
+Large projects often have many compile units with overlapping module graphs. By default, `zlinter` uses all compile units discovered in the evaluated `build.zig` configuration. To significantly improve performance for large projects, you can limit that context to specific compile steps:
+
+```zig
+const exe = b.addExecutable(.{
+    .name = "my_app",
+    .root_module = app_module,
+});
+
+var builder = zlinter.builder(b, .{});
+builder.addCompileUnit(exe);
+```
+
 ## Supported zig versions
 
 The plan is to support `master` (mostly because its an important exercise in keeping up to date with whats changing in zig) and the latest previous version.

--- a/build.zig
+++ b/build.zig
@@ -83,6 +83,7 @@ pub fn builder(b: *std.Build, options: BuilderOptions) StepBuilder {
         .rules = .empty,
         .exclude = .empty,
         .include = .empty,
+        .compile_unit_names = .empty,
         .options = .{
             .optimize = options.optimize,
             .target = options.target orelse b.graph.host,
@@ -111,6 +112,7 @@ const StepBuilder = struct {
     rules: std.ArrayList(BuiltRule),
     include: std.ArrayList(LintIncludeSource),
     exclude: std.ArrayList(LintExcludeSource),
+    compile_unit_names: std.ArrayList([]const u8),
     options: BuildOptions,
     b: *std.Build,
 
@@ -146,6 +148,16 @@ const StepBuilder = struct {
     pub fn addSource(self: *StepBuilder, source: LintIncludeSource) void {
         const arena = self.b.allocator;
         self.include.append(arena, source) catch @panic("OOM");
+    }
+
+    /// Adds a compile unit whose module/import context should be used while
+    /// linting.
+    ///
+    /// If no compile units are configured then zlinter uses all compile units
+    /// discovered in the evaluated build configuration.
+    pub fn addCompileUnit(self: *StepBuilder, compile: *std.Build.Step.Compile) void {
+        const arena = self.b.allocator;
+        self.compile_unit_names.append(arena, compile.step.name) catch @panic("OOM");
     }
 
     /// Set the paths to include or exclude when running the linter.
@@ -213,6 +225,7 @@ const StepBuilder = struct {
             },
             self.include.items,
             self.exclude.items,
+            self.compile_unit_names.items,
             self.options,
         );
     }
@@ -477,6 +490,7 @@ pub fn build(b: *std.Build) void {
             .{ .module = zlinter_lib_module },
             include.items,
             exclude.items,
+            &.{},
             .{
                 .target = target,
                 .optimize = if (tracy) .ReleaseSafe else .Debug,
@@ -533,6 +547,7 @@ fn buildStep(
     },
     include: []const LintIncludeSource,
     exclude: []const LintExcludeSource,
+    compile_unit_names: []const []const u8,
     options: BuildOptions,
 ) *std.Build.Step {
     const zlinter_lib_module: *std.Build.Module, const exe_file: std.Build.LazyPath, const build_rules_exe_file: std.Build.LazyPath = switch (zlinter) {
@@ -628,6 +643,7 @@ fn buildStep(
         // dependency graph is correct.
         .include_paths = null,
         .exclude_paths = null,
+        .compile_unit_names = if (compile_unit_names.len > 0) compile_unit_names else null,
     }, .{}, &buff.writer) catch @panic("Invalid build info");
 
     const stdin_bytes = buff.written();

--- a/build.zig
+++ b/build.zig
@@ -490,7 +490,12 @@ pub fn build(b: *std.Build) void {
             .{ .module = zlinter_lib_module },
             include.items,
             exclude.items,
-            &.{},
+            &.{
+                // Probably unstable but good enough for our internal use
+                // and easy to fix if it breaks. Users should never do this
+                // though.....
+                "compile exe zlinter Debug native",
+            },
             .{
                 .target = target,
                 .optimize = if (tracy) .ReleaseSafe else .Debug,

--- a/src/exe/run_linter.zig
+++ b/src/exe/run_linter.zig
@@ -257,7 +257,7 @@ fn runLinterRules(
         .type_store = .init(runtime),
         .decl_store = .init(runtime),
     };
-    try session.init();
+    try session.init(args.build_info);
 
     var enabled_rules = enabledRules(args.rules);
 

--- a/src/exe/run_linter.zig
+++ b/src/exe/run_linter.zig
@@ -363,6 +363,10 @@ fn runLinterRules(
             const rule_id: RuleId = @intCast(rule_index);
 
             const rule = rules[rule_id];
+            const rule_zone = tracy.traceNamed(@src(), "run_linter.rule");
+            defer rule_zone.end();
+            rule_zone.addText(rule.rule_id);
+            rule_zone.addText(cwd_rel_path);
             if (try rule.run(
                 rule,
                 &session,

--- a/src/lib/Args.zig
+++ b/src/lib/Args.zig
@@ -694,6 +694,35 @@ test "allocParse with include_paths and exclude_paths" {
     }), args);
 }
 
+test "allocParse with compile_unit_names" {
+    const bytes =
+        \\.{
+        \\  .compile_unit_names = .{"my_app", "my_lib_tests"},
+        \\}
+    ;
+
+    var backing: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer backing.deinit();
+
+    try backing.writer.writeInt(u32, @intCast(bytes.len), .little);
+    try backing.writer.writeAll(bytes);
+
+    var stdin_fbs = std.Io.Reader.fixed(backing.written());
+    const args = try allocParse(
+        testing.cliArgs(&.{"--stdin"}),
+        &.{},
+        std.testing.allocator,
+        &stdin_fbs,
+    );
+    defer args.deinit(std.testing.allocator);
+
+    try std.testing.expectEqualDeep(testing.expected(.{
+        .build_info = BuildInfo{
+            .compile_unit_names = @constCast(&[_][]const u8{ "my_app", "my_lib_tests" }),
+        },
+    }), args);
+}
+
 test "allocParse with exclude and include files" {
     var stdin_fbs = std.Io.Reader.fixed("");
 

--- a/src/lib/BuildInfo.zig
+++ b/src/lib/BuildInfo.zig
@@ -12,6 +12,10 @@ include_paths: ?[]const []const u8 = null,
 /// piped into the zlinter execution.
 exclude_paths: ?[]const []const u8 = null,
 
+/// Compile unit step names whose module/import contexts should be used while
+/// linting. If null, all discovered compile units are used.
+compile_unit_names: ?[]const []const u8 = null,
+
 pub const default: BuildInfo = .{};
 
 pub fn deinit(self: BuildInfo, gpa: std.mem.Allocator) void {
@@ -23,6 +27,11 @@ pub fn deinit(self: BuildInfo, gpa: std.mem.Allocator) void {
     if (self.include_paths) |paths| {
         for (paths) |p| gpa.free(p);
         gpa.free(paths);
+    }
+
+    if (self.compile_unit_names) |names| {
+        for (names) |name| gpa.free(name);
+        gpa.free(names);
     }
 }
 

--- a/src/lib/session/DeclStore.zig
+++ b/src/lib/session/DeclStore.zig
@@ -6,6 +6,12 @@ decl_id_by_ast_node: std.AutoHashMapUnmanaged(DeclAstNodeKey, DeclId) = .empty,
 decl_ids_by_file: std.AutoHashMapUnmanaged(FileStore.FileId, std.ArrayList(DeclId)) = .empty,
 scope_id_by_owner_node: std.AutoHashMapUnmanaged(ScopeOwnerKey, ScopeId) = .empty,
 scope_id_by_owner_decl: std.AutoHashMapUnmanaged(DeclId, ScopeId) = .empty,
+import_member_by_context: std.HashMapUnmanaged(
+    ImportMemberKey,
+    ?DeclId,
+    ImportMemberKey.context,
+    std.hash_map.default_max_load_percentage,
+) = .empty,
 
 /// Lives for the full linter invocation.
 runtime: *const LintRuntime,
@@ -92,6 +98,73 @@ const ScopeOwnerKey = enum(u64) {
     fn init(file_id: FileStore.FileId, owner_node: std.zig.Ast.Node.Index) ScopeOwnerKey {
         return @enumFromInt(packFileNodeKey(file_id, owner_node));
     }
+};
+
+const ImportMemberKey = struct {
+    parent_file_id: FileStore.FileId,
+    init_node: std.zig.Ast.Node.Index,
+    module_id: ?ModuleStore.ModuleId,
+    root_file_id: ?FileStore.FileId,
+    member_name: []const u8,
+
+    fn init(
+        ctx: ResolveContext,
+        parent_file_id: FileStore.FileId,
+        init_node: std.zig.Ast.Node.Index,
+        member_name: []const u8,
+    ) ImportMemberKey {
+        return .{
+            .parent_file_id = parent_file_id,
+            .init_node = init_node,
+            .module_id = ctx.module_id,
+            .root_file_id = ctx.root_file_id,
+            .member_name = member_name,
+        };
+    }
+
+    const context = struct {
+        pub fn hash(_: context, key: ImportMemberKey) u64 {
+            var hasher = std.hash.Wyhash.init(0);
+            std.hash.autoHash(&hasher, key.parent_file_id);
+            std.hash.autoHash(&hasher, key.init_node);
+            hashOptionalModuleId(&hasher, key.module_id);
+            hashOptionalFileId(&hasher, key.root_file_id);
+            hasher.update(key.member_name);
+            return hasher.final();
+        }
+
+        pub fn eql(_: context, a: ImportMemberKey, b: ImportMemberKey) bool {
+            return a.parent_file_id == b.parent_file_id and
+                a.init_node == b.init_node and
+                a.module_id == b.module_id and
+                a.root_file_id == b.root_file_id and
+                std.mem.eql(u8, a.member_name, b.member_name);
+        }
+
+        fn hashOptionalModuleId(
+            hasher: *std.hash.Wyhash,
+            maybe_module_id: ?ModuleStore.ModuleId,
+        ) void {
+            if (maybe_module_id) |module_id| {
+                std.hash.autoHash(hasher, true);
+                std.hash.autoHash(hasher, module_id);
+            } else {
+                std.hash.autoHash(hasher, false);
+            }
+        }
+
+        fn hashOptionalFileId(
+            hasher: *std.hash.Wyhash,
+            maybe_file_id: ?FileStore.FileId,
+        ) void {
+            if (maybe_file_id) |file_id| {
+                std.hash.autoHash(hasher, true);
+                std.hash.autoHash(hasher, file_id);
+            } else {
+                std.hash.autoHash(hasher, false);
+            }
+        }
+    };
 };
 
 fn packFileNodeKey(
@@ -1282,6 +1355,18 @@ fn resolveImportMember(
     const zone = tracy.traceNamed(@src(), "DeclStore.resolveImportMember");
     defer zone.end();
 
+    const key = ImportMemberKey.init(
+        ctx,
+        parent_file_id,
+        init_node,
+        member_name,
+    );
+    if (self.import_member_by_context.get(key)) |decl_id| {
+        zone.setValue(1);
+        return decl_id;
+    }
+    zone.setValue(0);
+
     const tree = ctx.file_store.fileTree(parent_file_id);
 
     var import_path_buffer: [std.fs.max_path_bytes]u8 = undefined;
@@ -1289,8 +1374,14 @@ fn resolveImportMember(
         tree,
         init_node,
         &import_path_buffer,
-    ) orelse
+    ) orelse {
+        oom(self.import_member_by_context.put(
+            self.runtime.sessionArena(),
+            self.ownedImportMemberKey(key),
+            null,
+        ));
         return null;
+    };
 
     const maybe_file_id = import_utils.resolveFile(
         ctx.withParent(parent_file_id),
@@ -1300,10 +1391,29 @@ fn resolveImportMember(
         return null;
     };
 
-    return if (maybe_file_id) |file_id|
+    const decl_id = if (maybe_file_id) |file_id|
         self.resolveFileRootMember(ctx.file_store, file_id, member_name)
     else
         null;
+
+    oom(self.import_member_by_context.put(
+        self.runtime.sessionArena(),
+        self.ownedImportMemberKey(key),
+        decl_id,
+    ));
+    return decl_id;
+}
+
+fn ownedImportMemberKey(
+    self: *DeclStore,
+    key: ImportMemberKey,
+) ImportMemberKey {
+    var owned_key = key;
+    owned_key.member_name = oom(self.runtime.sessionArena().dupe(
+        u8,
+        key.member_name,
+    ));
+    return owned_key;
 }
 
 fn isThisBuiltinCall(tree: std.zig.Ast, node: std.zig.Ast.Node.Index) bool {

--- a/src/lib/session/LintSession.zig
+++ b/src/lib/session/LintSession.zig
@@ -174,31 +174,73 @@ const ModuleResolution = struct {
     }
 };
 
-pub fn init(self: *LintContext) !void {
+pub fn init(self: *LintContext, build_info: BuildInfo) !void {
     const zone = tracy.traceNamed(@src(), "LintContext.init");
     defer zone.end();
 
     // Maybe one day we will care enough to use a fake for tests but for now
     // it's fine to ignore...
     self.root_build_config_id = if (!builtin.is_test)
-        try self.initBuildConfig()
+        try self.initBuildConfig(build_info)
     else
         null;
 }
 
-fn initBuildConfig(self: *LintContext) !BuildConfigStore.ConfigId {
+fn initBuildConfig(
+    self: *LintContext,
+    build_info: BuildInfo,
+) !BuildConfigStore.ConfigId {
     const zone = tracy.traceNamed(@src(), "LintContext.initBuildConfig");
     defer zone.end();
 
     const config_id = try self.build_config_store.resolve(".");
 
+    const compile_unit_names = build_info.compile_unit_names;
+    const matched_compile_units: ?[]bool = if (compile_unit_names) |names| matched: {
+        const matched = oom(self.runtime.sessionArena().alloc(bool, names.len));
+        @memset(matched, false);
+        break :matched matched;
+    } else null;
+
     const build_config = self.build_config_store.buildConfig(config_id);
-    for (0..build_config.steps.len) |step_index|
+    for (0..build_config.steps.len) |step_index| {
+        const step = build_config.steps[step_index];
+        if (step.extended.cast(
+            build_config,
+            std.Build.Configuration.Step.Compile,
+        ) == null) continue;
+
+        if (compile_unit_names) |names| {
+            const step_name = step.name.slice(build_config);
+            const name_index = indexOfName(names, step_name) orelse continue;
+            matched_compile_units.?[name_index] = true;
+        }
+
         try self.consumeBuildConfigStep(
             config_id,
             @enumFromInt(step_index),
         );
+    }
+
+    if (compile_unit_names) |names| {
+        for (matched_compile_units.?, 0..) |matched, index| {
+            if (!matched) {
+                std.log.err("Selected compile unit '{s}' was not found in the evaluated build configuration", .{
+                    names[index],
+                });
+                return error.InvalidBuildConfig;
+            }
+        }
+    }
+
     return config_id;
+}
+
+fn indexOfName(names: []const []const u8, needle: []const u8) ?usize {
+    for (names, 0..) |name, index| {
+        if (std.mem.eql(u8, name, needle)) return index;
+    }
+    return null;
 }
 
 fn consumeBuildConfigStep(
@@ -2919,6 +2961,7 @@ const results = @import("../results.zig");
 const std = @import("std");
 const testing = @import("../testing.zig");
 const tracy = @import("tracy");
+const BuildInfo = @import("../BuildInfo.zig");
 const BuildConfigStore = @import("BuildConfigStore.zig");
 const CompileContext = @import("CompileContext.zig");
 const DeclStore = @import("DeclStore.zig");

--- a/src/lib/session/LintSession.zig
+++ b/src/lib/session/LintSession.zig
@@ -225,8 +225,9 @@ fn initBuildConfig(
     if (compile_unit_names) |names| {
         for (matched_compile_units.?, 0..) |matched, index| {
             if (!matched) {
-                std.log.err("Selected compile unit '{s}' was not found in the evaluated build configuration", .{
+                std.log.err("Selected compile unit \"{s}\" was not found in the evaluated build configuration. Available compile units: {s}", .{
                     names[index],
+                    self.allocCompileUnitNamesForDebugging(build_config) catch "<ERROR>",
                 });
                 return error.InvalidBuildConfig;
             }
@@ -241,6 +242,29 @@ fn indexOfName(names: []const []const u8, needle: []const u8) ?usize {
         if (std.mem.eql(u8, name, needle)) return index;
     }
     return null;
+}
+
+fn allocCompileUnitNamesForDebugging(
+    self: *LintContext,
+    build_config: *const std.Build.Configuration,
+) ![]const u8 {
+    var writer: std.Io.Writer.Allocating = .init(self.runtime.sessionArena());
+
+    var written_any = false;
+    for (build_config.steps) |step| {
+        if (step.extended.cast(
+            build_config,
+            std.Build.Configuration.Step.Compile,
+        ) == null) continue;
+
+        if (written_any) try writer.writer.writeAll(", ");
+        try writer.writer.print("\"{s}\"", .{step.name.slice(build_config)});
+        written_any = true;
+    }
+
+    if (!written_any) try writer.writer.writeAll("(none)");
+
+    return writer.toOwnedSlice();
 }
 
 fn consumeBuildConfigStep(

--- a/src/lib/session/LintSession.zig
+++ b/src/lib/session/LintSession.zig
@@ -18,6 +18,7 @@ module_ids_by_file: std.AutoHashMapUnmanaged(FileStore.FileId, std.ArrayList(Mod
 module_file_index_built: bool = false,
 resolved_decl_types_by_module: std.AutoHashMapUnmanaged(ResolvedDeclTypeKey, ResolvedDeclType) = .empty,
 resolved_decl_by_module_file_node: std.AutoHashMapUnmanaged(ResolvedNodeDeclKey, ?DeclStore.DeclId) = .empty,
+decl_cands_by_node: std.AutoHashMapUnmanaged(FileNodeKey, []const DeclCandidate) = .empty,
 decl_value_summary_by_module: std.AutoHashMapUnmanaged(ResolvedDeclSummaryKey, ?TypeStore.TypeSummary) = .empty,
 decl_summary_cands_by_decl: std.AutoHashMapUnmanaged(DeclStore.DeclId, []const DeclValueSummaryCandidate) = .empty,
 type_annotation_cands_by_node: std.AutoHashMapUnmanaged(FileNodeKey, []const ValueTypeAnnotationCandidate) = .empty,
@@ -490,6 +491,10 @@ pub fn moduleIdsForFile(
     self: *LintContext,
     file_id: FileStore.FileId,
 ) []const ModuleStore.ModuleId {
+    const zone = tracy.traceNamed(@src(), "LintContext.moduleIdsForFile");
+    defer zone.end();
+    zone.setValue(file_id.toIndex());
+
     self.ensureModuleIdsByFile(self.runtime.sessionArena());
 
     const cached = self.module_ids_by_file.get(file_id) orelse fallback: {
@@ -515,6 +520,10 @@ fn ensureModuleIdsByFile(
     self: *LintContext,
     gpa: std.mem.Allocator,
 ) void {
+    const zone = tracy.traceNamed(@src(), "LintContext.ensureModuleIdsByFile");
+    defer zone.end();
+    zone.setValue(@intFromBool(self.module_file_index_built));
+
     if (self.module_file_index_built) return;
 
     for (self.compile_contexts.items(.root_module)) |root_module_id| {
@@ -562,6 +571,10 @@ fn indexModuleFiles(
     root_module_id: ModuleStore.ModuleId,
     gpa: std.mem.Allocator,
 ) void {
+    const zone = tracy.traceNamed(@src(), "LintContext.indexModuleFiles");
+    defer zone.end();
+    zone.setValue(root_module_id.toIndex());
+
     const compile_root_file_id = self.module_store.rootFileId(root_module_id);
 
     var visited = std.AutoHashMapUnmanaged(ReachKey, void).empty;
@@ -782,7 +795,7 @@ fn resolveTypeOfNodeForModule(
     const zone = tracy.traceNamed(@src(), "LintContext.resolveTypeOfNode");
     defer zone.end();
 
-    const immediate_decl_id = self.immediateDeclForNode(module_id, doc, node);
+    const immediate_decl_id = self.resolveDeclOfNodeForModule(module_id, doc, node);
     const resolved_decl_id = if (immediate_decl_id) |decl_id|
         self.decl_store.resolvedContainerDecl(
             &self.file_store,
@@ -834,6 +847,14 @@ pub fn resolveDeclCandidatesOfNode(
     doc: *const LintDocument,
     node: Ast.Node.Index,
 ) ![]const DeclCandidate {
+    const key: FileNodeKey = .{
+        .file_id = doc.file_id,
+        .node = node,
+    };
+    if (self.decl_cands_by_node.get(key)) |cached| {
+        return cached;
+    }
+
     var candidates = std.ArrayList(DeclCandidate).empty;
     const module_ids = self.moduleIdsForFile(doc.file_id);
     for (module_ids) |module_id| {
@@ -844,7 +865,17 @@ pub fn resolveDeclCandidatesOfNode(
             });
         }
     }
-    return candidates.items;
+
+    const owned = try self.runtime.sessionArena().dupe(
+        DeclCandidate,
+        candidates.items,
+    );
+    oom(self.decl_cands_by_node.put(
+        self.runtime.sessionArena(),
+        key,
+        owned,
+    ));
+    return owned;
 }
 
 /// Resolves a member declaration from a container/type declaration.
@@ -1558,13 +1589,19 @@ fn resolveDeclValueSummaryForModule(
     module_id: ModuleStore.ModuleId,
     decl_id: DeclStore.DeclId,
 ) ?TypeStore.TypeSummary {
+    const zone = tracy.traceNamed(@src(), "LintContext.resolveDeclValueSummaryForModule");
+    defer zone.end();
+
     const key: ResolvedDeclSummaryKey = .{
         .module_id = module_id,
         .decl_id = decl_id,
     };
-    if (self.decl_value_summary_by_module.get(key)) |summary|
+    if (self.decl_value_summary_by_module.get(key)) |summary| {
+        zone.setValue(1);
         return summary;
+    }
 
+    zone.setValue(0);
     const summary = self.resolveDeclValueSummaryDepth(module_id, decl_id, 16);
     oom(self.decl_value_summary_by_module.put(
         self.runtime.sessionArena(),
@@ -1580,8 +1617,13 @@ pub fn resolveDeclValueSummaryCandidates(
     self: *LintContext,
     decl_id: DeclStore.DeclId,
 ) ![]const DeclValueSummaryCandidate {
-    if (self.decl_summary_cands_by_decl.get(decl_id)) |cached|
+    const zone = tracy.traceNamed(@src(), "LintContext.resolveDeclValueSummaryCandidates");
+    defer zone.end();
+
+    if (self.decl_summary_cands_by_decl.get(decl_id)) |cached| {
+        zone.setValue(cached.len);
         return cached;
+    }
 
     var candidates = std.ArrayList(DeclValueSummaryCandidate).empty;
     const module_ids = self.moduleIdsForDecl(decl_id);
@@ -1604,6 +1646,7 @@ pub fn resolveDeclValueSummaryCandidates(
         decl_id,
         owned,
     ));
+    zone.setValue(owned.len);
     return owned;
 }
 
@@ -1614,6 +1657,10 @@ pub fn resolveDeclValueSummaryCandidatesFromCandidates(
     arena: std.mem.Allocator,
     decl_candidates: []const DeclCandidate,
 ) ![]const DeclValueSummaryCandidate {
+    const zone = tracy.traceNamed(@src(), "LintContext.resolveDeclValueSummaryCandidatesFromCandidates");
+    defer zone.end();
+    zone.setValue(decl_candidates.len);
+
     var candidates = std.ArrayList(DeclValueSummaryCandidate).empty;
     for (decl_candidates) |candidate| {
         const summary = self.resolveDeclValueSummaryForModule(
@@ -1636,11 +1683,15 @@ pub fn resolveValueTypeAnnotationCandidates(
     doc: *const LintDocument,
     type_node: Ast.Node.Index,
 ) ![]const ValueTypeAnnotationCandidate {
+    const zone = tracy.traceNamed(@src(), "LintContext.resolveValueTypeAnnotationCandidates");
+    defer zone.end();
+
     const key: FileNodeKey = .{
         .file_id = doc.file_id,
         .node = type_node,
     };
     if (self.type_annotation_cands_by_node.get(key)) |cached| {
+        zone.setValue(cached.len);
         return cached;
     }
 
@@ -1665,6 +1716,7 @@ pub fn resolveValueTypeAnnotationCandidates(
             key,
             owned,
         ));
+        zone.setValue(owned.len);
         return owned;
     }
 
@@ -1687,6 +1739,7 @@ pub fn resolveValueTypeAnnotationCandidates(
             key,
             owned,
         ));
+        zone.setValue(owned.len);
         return owned;
     }
 
@@ -1725,6 +1778,7 @@ pub fn resolveValueTypeAnnotationCandidates(
         key,
         owned,
     ));
+    zone.setValue(owned.len);
     return owned;
 }
 
@@ -1735,6 +1789,10 @@ fn resolveDeclValueSummaryDepth(
     decl_id: DeclStore.DeclId,
     remaining_depth: u8,
 ) ?TypeStore.TypeSummary {
+    const zone = tracy.traceNamed(@src(), "LintContext.resolveDeclValueSummaryDepth");
+    defer zone.end();
+    zone.setValue(remaining_depth);
+
     if (remaining_depth == 0) return null;
 
     const file_id = self.decl_store.declFileId(decl_id);

--- a/src/lib/session/LintSession.zig
+++ b/src/lib/session/LintSession.zig
@@ -174,14 +174,14 @@ const ModuleResolution = struct {
     }
 };
 
-pub fn init(self: *LintContext, build_info: BuildInfo) !void {
+pub fn init(self: *LintContext, lint_build_info: BuildInfo) !void {
     const zone = tracy.traceNamed(@src(), "LintContext.init");
     defer zone.end();
 
     // Maybe one day we will care enough to use a fake for tests but for now
     // it's fine to ignore...
     self.root_build_config_id = if (!builtin.is_test)
-        try self.initBuildConfig(build_info)
+        try self.initBuildConfig(lint_build_info)
     else
         null;
 }

--- a/src/lib/session/LintSession.zig
+++ b/src/lib/session/LintSession.zig
@@ -188,19 +188,19 @@ pub fn init(self: *LintContext, build_info: BuildInfo) !void {
 
 fn initBuildConfig(
     self: *LintContext,
-    build_info: BuildInfo,
+    lint_build_info: BuildInfo,
 ) !BuildConfigStore.ConfigId {
     const zone = tracy.traceNamed(@src(), "LintContext.initBuildConfig");
     defer zone.end();
 
     const config_id = try self.build_config_store.resolve(".");
 
-    const compile_unit_names = build_info.compile_unit_names;
-    const matched_compile_units: ?[]bool = if (compile_unit_names) |names| matched: {
-        const matched = oom(self.runtime.sessionArena().alloc(bool, names.len));
-        @memset(matched, false);
-        break :matched matched;
-    } else null;
+    const compile_unit_names = lint_build_info.compile_unit_names;
+    var matched_compile_units: ?std.bit_set.Dynamic =
+        if (compile_unit_names) |names|
+            try .initEmpty(self.runtime.sessionArena(), names.len)
+        else
+            null;
 
     const build_config = self.build_config_store.buildConfig(config_id);
     for (0..build_config.steps.len) |step_index| {
@@ -211,9 +211,11 @@ fn initBuildConfig(
         ) == null) continue;
 
         if (compile_unit_names) |names| {
-            const step_name = step.name.slice(build_config);
-            const name_index = indexOfName(names, step_name) orelse continue;
-            matched_compile_units.?[name_index] = true;
+            const name_index = indexOfName(
+                names,
+                step.name.slice(build_config),
+            ) orelse continue;
+            matched_compile_units.?.set(name_index);
         }
 
         try self.consumeBuildConfigStep(
@@ -223,14 +225,13 @@ fn initBuildConfig(
     }
 
     if (compile_unit_names) |names| {
-        for (matched_compile_units.?, 0..) |matched, index| {
-            if (!matched) {
-                std.log.err("Selected compile unit \"{s}\" was not found in the evaluated build configuration. Available compile units: {s}", .{
-                    names[index],
-                    self.allocCompileUnitNamesForDebugging(build_config) catch "<ERROR>",
-                });
-                return error.InvalidBuildConfig;
-            }
+        var it = matched_compile_units.?.iterator(.{ .kind = .unset });
+        while (it.next()) |index| {
+            std.log.err("Selected compile unit \"{s}\" was not found in the evaluated build configuration. Available compile units: {s}", .{
+                names[index],
+                self.allocCompileUnitNamesForDebugging(build_config) catch "<ERROR>",
+            });
+            return error.InvalidBuildConfig;
         }
     }
 
@@ -263,6 +264,7 @@ fn allocCompileUnitNamesForDebugging(
     }
 
     if (!written_any) try writer.writer.writeAll("(none)");
+    try writer.writer.flush();
 
     return writer.toOwnedSlice();
 }

--- a/src/lib/session/LintSession.zig
+++ b/src/lib/session/LintSession.zig
@@ -397,8 +397,8 @@ pub fn resolveFile(self: *LintContext, input_path: []const u8) !FileStore.FileId
     return id;
 }
 
-/// Resolves cached type information for a file in every module context that can
-/// reach it.
+/// Resolves file-level type information and records declarations for module
+/// contexts that can reach it.
 ///
 /// This avoids choosing one active module when imports can resolve to
 /// different declarations across compile units.
@@ -424,7 +424,7 @@ pub fn resolveFileTypes(
     }
 }
 
-/// Resolves type caches for a file under one module root.
+/// Ensures declarations are available for module-specific lazy resolution.
 fn resolveFileTypesForModule(
     self: *LintContext,
     file_id: FileStore.FileId,
@@ -433,12 +433,8 @@ fn resolveFileTypesForModule(
     const zone = tracy.traceNamed(@src(), "LintContext.resolveFileTypesForModule");
     defer zone.end();
 
+    _ = module_id;
     _ = self.decl_store.store(file_id, &self.file_store);
-
-    var it = self.decl_store.fileDeclIterator(file_id);
-    while (it.next()) |decl_id| {
-        _ = self.cacheResolvedDeclTypeForModule(module_id, decl_id);
-    }
 }
 
 /// Returns cached type information for a declaration in one module context,
@@ -2206,8 +2202,7 @@ fn typeSummaryFromValueNode(
     );
 }
 
-/// Resolves an `@import` root declaration in the active module context and
-/// seeds that imported file's module-specific type cache.
+/// Resolves an `@import` root declaration in the active module context.
 fn resolveImportRootDecl(
     self: *LintContext,
     module_id: ModuleStore.ModuleId,

--- a/src/lib/testing.zig
+++ b/src/lib/testing.zig
@@ -108,7 +108,7 @@ pub fn initFakeContext(
         .type_store = .init(runtime),
         .decl_store = .init(runtime),
     };
-    session.init() catch @panic("failed to initialize fake lint session");
+    session.init(.default) catch @panic("failed to initialize fake lint session");
     return session;
 }
 

--- a/src/rules/declaration_naming.zig
+++ b/src/rules/declaration_naming.zig
@@ -70,6 +70,10 @@ fn run(
     doc: *const zlinter.session.LintDocument,
     options: zlinter.rules.RunOptions,
 ) zlinter.rules.RunError!?zlinter.results.LintResult {
+    const zone = zlinter.tracy.traceNamed(@src(), "rule.declaration_naming");
+    defer zone.end();
+    zone.addText(doc.absPath(session));
+
     const config = options.getConfig(Config);
     const session_arena = session.runtime.sessionArena();
     const rule_arena = session.runtime.ruleArena();

--- a/src/rules/field_naming.zig
+++ b/src/rules/field_naming.zig
@@ -97,6 +97,10 @@ fn run(
     doc: *const zlinter.session.LintDocument,
     options: zlinter.rules.RunOptions,
 ) zlinter.rules.RunError!?zlinter.results.LintResult {
+    const zone = zlinter.tracy.traceNamed(@src(), "rule.field_naming");
+    defer zone.end();
+    zone.addText(doc.absPath(session));
+
     const config = options.getConfig(Config);
     const session_arena = session.runtime.sessionArena();
 

--- a/src/rules/function_naming.zig
+++ b/src/rules/function_naming.zig
@@ -56,6 +56,10 @@ fn run(
     doc: *const zlinter.session.LintDocument,
     options: zlinter.rules.RunOptions,
 ) zlinter.rules.RunError!?zlinter.results.LintResult {
+    const zone = zlinter.tracy.traceNamed(@src(), "rule.function_naming");
+    defer zone.end();
+    zone.addText(doc.absPath(session));
+
     const config = options.getConfig(Config);
     const session_arena = session.runtime.sessionArena();
     const rule_arena = session.runtime.ruleArena();

--- a/src/rules/no_deprecated.zig
+++ b/src/rules/no_deprecated.zig
@@ -28,6 +28,10 @@ fn run(
     doc: *const zlinter.session.LintDocument,
     options: zlinter.rules.RunOptions,
 ) zlinter.rules.RunError!?zlinter.results.LintResult {
+    const zone = zlinter.tracy.traceNamed(@src(), "rule.no_deprecated");
+    defer zone.end();
+    zone.addText(doc.absPath(session));
+
     const config = options.getConfig(Config);
     const session_arena = session.runtime.sessionArena();
     const rule_arena = session.runtime.ruleArena();

--- a/src/rules/no_unused.zig
+++ b/src/rules/no_unused.zig
@@ -27,6 +27,10 @@ fn run(
     doc: *const zlinter.session.LintDocument,
     options: zlinter.rules.RunOptions,
 ) zlinter.rules.RunError!?zlinter.results.LintResult {
+    const zone = zlinter.tracy.traceNamed(@src(), "rule.no_unused");
+    defer zone.end();
+    zone.addText(doc.absPath(session));
+
     const config = options.getConfig(Config);
     if (config.container_declaration == .off) return null;
 


### PR DESCRIPTION
I'm torn on whether addCompileUnit should be required so usage is explicit. Alternative maybe some tree pruning can be applied to reduce duplicated parts of the different compiled units but this feels kinda overcomplicated when more than likely the user is wanting to target specific compiled units already