### PR TITLE
chore: catch up with filename change in #164

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -12,7 +12,7 @@
     },
     .paths = .{
         "build.zig",
-        "build_rules.zig",
+        "build_lint_builtin.zig",
         "build_docs.zig",
         "build.zig.zon",
         "src",


### PR DESCRIPTION
In #164 at https://github.com/KurtWagner/zlinter/commit/7f19814738f0c0bebfd29172802cee0e535823b7 `build_rules` got renamed into `build_lint_builtin` - this change makes sure to also include this new file when integrating zlinter via my projects `build.zig.zon`